### PR TITLE
Adding AMD support

### DIFF
--- a/src/fastclick.js
+++ b/src/fastclick.js
@@ -295,7 +295,7 @@
 
 	if (typeof define === "function" && define.amd) {
 		// AMD. Register as an anonymous module.
-		define(FastClick);
+		define(function() { return FastClick; });
 	} else {
 		// Browser global
 		window.FastClick = FastClick;


### PR DESCRIPTION
Hi,
i've added AMD (Asynchronous Module Definition) support to the FastClick library. This allows the library to be loaded with an AMD loader, such as Require.js (used by many big websites, including the BBC) and allows for easier dependency and lazy loading.

For sites that don't use AMD the module is still available as a global variable, so this shouldn't break any existing code.
