### PR TITLE
Fix ghost focus

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -54,7 +54,13 @@ function FastClick(layer) {
 	this.onTouchMove = function() { FastClick.prototype.onTouchMove.apply(that, arguments); };
 	this.onTouchEnd = function() { FastClick.prototype.onTouchEnd.apply(that, arguments); };
 	this.onTouchCancel = function() { FastClick.prototype.onTouchCancel.apply(that, arguments); };
-
+	this.onFocus = function(event){
+		document.removeEventListener('focus', that.onFocus, true);
+		event.stopPropagation();
+		event.preventDefault();
+		event.target.blur();
+		return false;
+	};
 	// Devices that don't support touch don't need FastClick
 	if (typeof window.ontouchstart === 'undefined') {
 		return;
@@ -249,6 +255,12 @@ FastClick.prototype.onTouchEnd = function(event) {
 	}
 
 	this.trackingClick = false;
+
+	document.removeEventListener('focus', this.onFocus, true);
+	document.addEventListener('focus', this.onFocus, true);
+	setTimeout(function(){
+		document.removeEventListener('focus', this.onFocus, false);
+	}, 400);
 
 	if (targetElement.nodeName.toLowerCase() === 'label' && targetElement.htmlFor) {
 		forElement = document.getElementById(targetElement.htmlFor);


### PR DESCRIPTION
Test case: Click on a button to transition (css3 slide) to next page, if on next page there is an input right there the position of the button on previous page, the input will get focus and soft keyboard open up.

Before:
jsfiddle: http://jsfiddle.net/sX3WJ/
mobile browser: http://fiddle.jshell.net/sX3WJ/show/

After:
jsfiddle: http://jsfiddle.net/sX3WJ/1/
mobile browser: http://fiddle.jshell.net/sX3WJ/1/show/
