### PR TITLE
fix package.json and module.exports

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -397,3 +397,10 @@ if (typeof define === 'function' && define.amd) {
 		return FastClick;
 	});
 }
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = function(layer){
+    return new FastClick(layer)
+  }
+  module.exports.FastClick = FastClick
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "Matthew Caruana Galizia",
     "Rowan Beentje"
   ],
+  "main": "lib/fastclick.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/ftlabs/fastclick.git"


### PR DESCRIPTION
now `browserify -r fastclick` and `var fastclick = require('fastclick')` or `var FastClick = require('fastclick').FastClick` works
