### PR TITLE
fixes "failed to require "fastclick" from (...)"

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,6 +2,7 @@
   "name": "fastclick",
   "description": "Polyfill to remove click delays on browsers with touch UIs.",
   "version": "0.4.2",
+  "main": "lib/fastclick.js",
   "scripts": [
     "lib/fastclick.js"
   ],


### PR DESCRIPTION
From the [component/component](https://github.com/component/component) [wiki](https://github.com/component/component/wiki/Spec):

> It is recommended that you use "index.js" for the main component file, however if you use another filename, you **MUST** define a "main" field for that. A component **MUST** have only one "main" file specified, and it **MUST** still be listed in the "scripts" array.
