### PR TITLE
iOS doubletap behavior on input fields

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -197,6 +197,7 @@ FastClick.prototype.onTouchStart = function(event) {
 	this.touchStartX = touch.pageX;
 	this.touchStartY = touch.pageY;
 
+	event.preventDefault();
 	return true;
 };
 
@@ -280,6 +281,13 @@ FastClick.prototype.onTouchEnd = function(event) {
 		return true;
 	}
 
+	if (event.timeStamp - this.lastClickTime < 200) {
+		this.cancelNextClick = true
+		return true;
+	}
+
+	this.lastClickTime = event.timeStamp
+
 	trackingClickStart = this.trackingClickStart;
 	this.trackingClick = false;
 	this.trackingClickStart = 0;
@@ -299,11 +307,11 @@ FastClick.prototype.onTouchEnd = function(event) {
 			return false;
 		}
 	} else if (this.needsFocus(targetElement)) {
-
 		// If the touch started a while ago (best guess is 100ms based on tests for issue #36) then focus will be triggered anyway. Return early and unset the target element reference so that the subsequent click will be allowed through.
 
 		// Held clicks between 100ms and 150ms still created this behavior, so I lowered the threshold.
 		if ((event.timeStamp - trackingClickStart) > 100) {
+
 			this.targetElement = null;
 			return true;
 		}
@@ -349,6 +357,7 @@ FastClick.prototype.onTouchCancel = function() {
  */
 FastClick.prototype.onClick = function(event) {
 	'use strict';
+
 	var oldTargetElement;
 
 	if (event.forwardedTouchEvent) {
@@ -376,8 +385,8 @@ FastClick.prototype.onClick = function(event) {
 	// Derive and check the target element to see whether the click needs to be permitted;
 	// unless explicitly enabled, prevent non-touch click events from triggering actions,
 	// to prevent ghost/doubleclicks.
-	if (!this.needsClick(oldTargetElement)) {
-
+	if (!this.needsClick(oldTargetElement) || this.cancelNextClick) {
+		this.cancelNextClick = false
 		// Prevent any user-added listeners declared on FastClick element from being fired.
 		if (event.stopImmediatePropagation) {
 			event.stopImmediatePropagation();


### PR DESCRIPTION
Stemming from issue 36 (https://github.com/ftlabs/fastclick/issues/36), lowered the threshold for held taps to prevent jumping fields.  Then, corrected double-tap behavior.

See the fiddle here:
http://jsfiddle.net/xJrsW/
open this URL in iOS: http://jsfiddle.net/xJrsW/embedded/result/

Prevented default behavior on touch end to prevent phantom clicks when double-tapping a field.
