### PR TITLE
iOS doubletap behavior on input fields UPDATE

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -197,7 +197,9 @@ FastClick.prototype.onTouchStart = function(event) {
 	this.touchStartX = touch.pageX;
 	this.touchStartY = touch.pageY;
 
-	event.preventDefault();
+	if (event.timeStamp - this.lastClickTime < 200) {
+		event.preventDefault();
+	}
 	return true;
 };
 


### PR DESCRIPTION
Added a condition on preventDefault on touchStart.  Fixed the bug I created with my last pull request.
