### PR TITLE
iOS alert/confirm bug fix

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -61,6 +61,12 @@ function FastClick(layer) {
 	 */
 	this.touchStartY = 0;
 
+	/**
+	 * Ingore touch end on iOS when alerts/confirms are used
+	 *
+	 * @type boolean
+	 ?*/
+	 this.skipTouchEnd = false;
 
 	/**
 	 * The FastClick layer.
@@ -144,6 +150,18 @@ function FastClick(layer) {
 
 
 /**
+ * Simple function to get the time in ms.  Used for checking the time it took to dispatch/handle a click event.
+ *
+ * @returns {integer} Returns the time in milliseconds
+ */
+
+FastClick.prototype.getTime = function(){
+	var d = new Date();
+	var n = d.getTime();
+	return n;
+}
+
+/**
  * Android requires an exception for labels.
  *
  * @type boolean
@@ -206,7 +224,7 @@ FastClick.prototype.needsFocus = function(target) {
  */
 FastClick.prototype.sendClick = function(targetElement, event) {
 	'use strict';
-	var clickEvent, touch;
+	var clickEvent, touch, startTime, endTime;
 
 	// On some Android devices activeElement needs to be blurred otherwise the synthetic click will have no effect (#24)
 	if (document.activeElement && document.activeElement !== targetElement) {
@@ -219,7 +237,15 @@ FastClick.prototype.sendClick = function(targetElement, event) {
 	clickEvent = document.createEvent('MouseEvents');
 	clickEvent.initMouseEvent('click', true, true, window, 1, touch.screenX, touch.screenY, touch.clientX, touch.clientY, false, false, false, false, 0, null);
 	clickEvent.forwardedTouchEvent = true;
+	startTime=this.getTime();
 	targetElement.dispatchEvent(clickEvent);
+	var endTime=this.getTime();
+
+	//Since alert/confirms are blocking, we get the time difference between when we started and ended.  If it's over 200ms, then we assume the user
+	//has an alert/cofirm.  We then need to skip the next touchend event since iOS triggers a touchstart when dismissing the alert/confirm
+	if((endTime-startTime)>200){
+		this.skipTouchEnd=true;
+	}
 };
 
 
@@ -323,6 +349,13 @@ FastClick.prototype.findControl = function(labelElement) {
 FastClick.prototype.onTouchEnd = function(event) {
 	'use strict';
 	var forElement, trackingClickStart, targetElement = this.targetElement;
+
+    //Skip the touch end processing
+	if(this.skipTouchEnd){
+		this.skipTouchEnd=false;
+		return false;
+	}
+	
 
 	if (!this.trackingClick) {
 		return true;


### PR DESCRIPTION
This provides a fix for the iOS alert/confirm bug where touchstart is dispatched when dismissing the alert/confirm box.  What the fix does is checks how long the "click" event takes to process since alert/confirm are blocking, and if it's over 200ms, it sets a flag to skip the next touchend event so we do not send another synthetic click.

This isn't 100% perfect as synchronous ajax requests are also blocking.
