### PR TITLE
Work around incorrect element detection on iOS 6 in transitioning/scrolling layers (fixes #57)

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -176,6 +176,14 @@ FastClick.prototype.deviceIsIOS4 = FastClick.prototype.deviceIsIOS && (/OS 4_\d(
 
 
 /**
+ * iOS 6.0(+?) requires the target element to be manually derived
+ *
+ * @type boolean
+ */
+FastClick.prototype.deviceIsIOSWithBadTarget = FastClick.prototype.deviceIsIOS && (/OS ([6-9]|\d{2})_\d/).test(navigator.userAgent);
+
+
+/**
  * Determine whether a given element requires a native click.
  *
  * @param {EventTarget|Element} target Target DOM element
@@ -445,7 +453,7 @@ FastClick.prototype.findControl = function(labelElement) {
  */
 FastClick.prototype.onTouchEnd = function(event) {
 	'use strict';
-	var forElement, trackingClickStart, targetTagName, scrollParent, targetElement = this.targetElement;
+	var forElement, trackingClickStart, targetTagName, scrollParent, touch, targetElement = this.targetElement;
 
 	if (!this.trackingClick) {
 		return true;
@@ -462,6 +470,16 @@ FastClick.prototype.onTouchEnd = function(event) {
 	trackingClickStart = this.trackingClickStart;
 	this.trackingClick = false;
 	this.trackingClickStart = 0;
+
+	// On some iOS devices, the targetElement supplied with the event is invalid if the layer
+	// is performing a transition or scroll, and has to be re-detected manually. Note that
+	// for this to function correctly, it must be called *after* the event target is checked!
+	// See issue #57; also filed as rdar://13048589 .
+	if (this.deviceIsIOSWithBadTarget) {
+		touch = event.changedTouches[0];
+		targetElement = event.target;
+		targetElement = document.elementFromPoint(touch.pageX - window.pageXOffset, touch.pageY - window.pageYOffset);
+	}
 
 	targetTagName = targetElement.tagName.toLowerCase();
 	if (targetTagName === 'label') {


### PR DESCRIPTION
iOS 6.0 (and potentially beyond) has a bug where event.target gives an incorrect element if that element is within a parent that is currently being scrolled or CSS transitioned.  This works around the problem by performing manual detection in these circumstanced by using document.elementFromPoint with coordinates derived from the event, which works if preceded by an event.target.
