### PR TITLE
Ignore tests and examples dirs

### DIFF
--- a/component.json
+++ b/component.json
@@ -6,5 +6,9 @@
   "scripts": [
     "lib/fastclick.js"
   ],
+  "ignore": [
+    "examples/",
+    "tests/"
+  ],
   "license": "MIT"
 }


### PR DESCRIPTION
Bower wont pull in files and directories listed in the 'ignore' array.
