### PR TITLE
Should check if the needsclick class is present on input and buttons

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -204,6 +204,11 @@ FastClick.prototype.needsClick = function(target) {
 			return true;
 		}
 
+		// Check if the needsclick class is present (issue #92)
+		if ((/\bneedsclick\b/).test(target.className)) {
+			return true;
+		}
+
 		// Don't send a synthetic click to disabled inputs (issue #62)
 		return target.disabled;
 	case 'label':


### PR DESCRIPTION
In the FastClick.prototype.needsClick function, for button and input the needsclick class presence is not tested. Consequently if the button is enable, even it has the needsclick class, a synthetic click will be sent.

For example this is a problem on android 2.3 when trying to open the Facebook connect dialog.
