### PR TITLE
Support for mouseup event on elements

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -203,7 +203,7 @@ FastClick.prototype.needsClick = function(target) {
 		// Don't send a synthetic click to disabled inputs (issue #62)
 		if ((this.deviceIsIOS && target.type === 'file') || target.disabled) {
 			return true;
-		}		
+		}
 	} else if (nodeName === 'label' || nodeName === 'video') {
 		return true;
 	}
@@ -251,7 +251,7 @@ FastClick.prototype.needsFocus = function(target) {
  */
 FastClick.prototype.sendClick = function(targetElement, event) {
 	'use strict';
-	var clickEvent, touch;
+	var clickEvent, mouseupEvent, touch;
 
 	// On some Android devices activeElement needs to be blurred otherwise the synthetic click will have no effect (#24)
 	if (document.activeElement && document.activeElement !== targetElement) {
@@ -259,6 +259,11 @@ FastClick.prototype.sendClick = function(targetElement, event) {
 	}
 
 	touch = event.changedTouches[0];
+
+	mouseupEvent = document.createEvent('MouseEvents');
+	mouseupEvent.initMouseEvent('mouseup', true, true, window, 1, touch.screenX, touch.screenY, touch.clientX, touch.clientY, false, false, false, false, 0, null);
+	mouseupEvent.forwardedTouchEvent = true;
+	targetElement.dispatchEvent(mouseupEvent);
 
 	// Synthesise a click event, with an extra attribute so it can be tracked
 	clickEvent = document.createEvent('MouseEvents');
@@ -365,7 +370,7 @@ FastClick.prototype.onTouchStart = function(event) {
 				event.preventDefault();
 				return false;
 			}
-		
+
 			this.lastTouchIdentifier = touch.identifier;
 
 			// If the target element is a child of a scrollable layer (using -webkit-overflow-scrolling: touch) and:


### PR DESCRIPTION
This update resolves problem of blocked OnMouseup event on the element. In this commit the mouseup event is included inside sendClick().

Can we split this method and create new one e.g. sendMouseUp() and then trigger it in similar way to sendClick inside onTouchEnd()? Should we do this also for other events?
