### PR TITLE
This was complaining when our project linter was being run over it

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -369,7 +369,7 @@ FastClick.prototype.onTouchStart = function(event) {
 				event.preventDefault();
 				return false;
 			}
-		
+
 			this.lastTouchIdentifier = touch.identifier;
 
 			// If the target element is a child of a scrollable layer (using -webkit-overflow-scrolling: touch) and:


### PR DESCRIPTION
Should we even have the ftlabs coding standard tag at the top of public projects? Especially if we are not linting in automated tests.
