### PR TITLE
Fix for issue #113: prevent default for touchStart on certain versions of Android

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -170,6 +170,13 @@ function FastClick(layer) {
  */
 FastClick.prototype.deviceIsAndroid = navigator.userAgent.indexOf('Android') > 0;
 
+/**
+ * Certain versions of Android require preventing default for touch start.
+ *
+ * @type boolean
+ */
+FastClick.prototype.deviceHasBadTouchStart = FastClick.prototype.deviceIsAndroid
+        && (/^.*Android (2|3|4\.0)((?!Chrome\/[0-9]+).)*$/).test(navigator.userAgent);
 
 /**
  * iOS requires exceptions.
@@ -410,7 +417,8 @@ FastClick.prototype.onTouchStart = function(event) {
 	this.touchStartY = touch.pageY;
 
 	// Prevent phantom clicks on fast double-tap (issue #36)
-	if ((event.timeStamp - this.lastClickTime) < 200) {
+	if ((event.timeStamp - this.lastClickTime) < 200 
+            || (this.deviceHasBadTouchStart && !this.needsFocus(targetElement) && !this.needsClick(targetElement))) {
 		event.preventDefault();
 	}
 


### PR DESCRIPTION
Potential fix for https://github.com/ftlabs/fastclick/issues/113.  This has only undergone some basic testing, but it seems to be working for our use cases.
