### PR TITLE
Fix for regression introduced by #57 (fling scroll sends click, fix #42)

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -1,7 +1,7 @@
 /**
  * @preserve FastClick: polyfill to remove click delays on browsers with touch UIs.
  *
- * @version 0.6.7
+ * @version 0.6.8
  * @codingstandard ftlabs-jsv2
  * @copyright The Financial Times Limited [All Rights Reserved]
  * @license MIT License (see LICENSE.txt)
@@ -500,6 +500,7 @@ FastClick.prototype.onTouchEnd = function(event) {
 	if (this.deviceIsIOSWithBadTarget) {
 		touch = event.changedTouches[0];
 		targetElement = document.elementFromPoint(touch.pageX - window.pageXOffset, touch.pageY - window.pageYOffset);
+		targetElement.fastClickScrollParent = this.targetElement.fastClickScrollParent;
 	}
 
 	targetTagName = targetElement.tagName.toLowerCase();


### PR DESCRIPTION
Starting from 0.5.1 (first version to include #57 fix), the bug fixed by #42 reappeared: tapping on a currently scrolling container with `-webkit-overflow-scrolling: touch` sends a click on the underlying element (iOS 6); the expected behavior on iOS would be to just stop scrolling and not fire a click.

I haven't had much time to read through and understand the code (so the change may have side effects) but it restores the behavior of 0.5.0. So please consider this a bug report and adjust as needed.
