### PR TITLE
Temporarily disable/enable fastclick

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -37,6 +37,12 @@ function FastClick(layer) {
 	 */
 	this.trackingClickStart = 0;
 
+	/**
+	 * Disable Tracking
+	 *
+	 * @type boolean
+	 */
+	this.trackingDisabled = false;
 
 	/**
 	 * The element being tracked for a click.
@@ -362,6 +368,10 @@ FastClick.prototype.onTouchStart = function(event) {
 	'use strict';
 	var targetElement, touch, selection;
 
+	// Do nothing if tracking is disabled
+	if (this.trackingDisabled === true)
+		return true;
+
 	// Ignore multiple touches, otherwise pinch-to-zoom is prevented if both fingers are on the FastClick element (issue #111).
 	if (event.targetTouches.length > 1) {
 		return true;
@@ -470,6 +480,10 @@ FastClick.prototype.findControl = function(labelElement) {
 FastClick.prototype.onTouchEnd = function(event) {
 	'use strict';
 	var forElement, trackingClickStart, targetTagName, scrollParent, touch, targetElement = this.targetElement;
+
+	// Do nothing if tracking is disabled
+	if (this.trackingDisabled === true)
+		return true;
 
 	// If the touch has moved, cancel the click tracking
 	if (this.touchHasMoved(event)) {


### PR DESCRIPTION
I use fast click in an iPhone application.

There were some issues with scrolling the UIWebView and touch: sometime when I stop scrolling by a tap, fastclick take it as a click.

After some research, I find that the an easy way to do deal with this is to disable fastclick when I start scrolling and enable it when I stop.

So I had an option in fastclick to do that:

`fastclick.trackingDisabled = true/false;`

And to use it in Objective-C code, it look like something like that:

```
- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
{
    [webView stringByEvaluatingJavaScriptFromString:@"if (typeof(fastclick) != 'undefined') fastclick.trackingDisabled = true;"];
}

- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
{
    [webView stringByEvaluatingJavaScriptFromString:@"if (typeof(fastclick) != 'undefined') fastclick.trackingDisabled = false;"];
}

- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
{
    if (scrollView.isDecelerating == NO)
    {
        [webView stringByEvaluatingJavaScriptFromString:@"if (typeof(fastclick) != 'undefined') fastclick.trackingDisabled = false;"];        
    }
}
```
