### PR TITLE
Prevent NRE after manual re-detecting the targetElement on iOS

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -499,7 +499,8 @@ FastClick.prototype.onTouchEnd = function(event) {
 	// See issue #57; also filed as rdar://13048589 .
 	if (this.deviceIsIOSWithBadTarget) {
 		touch = event.changedTouches[0];
-		targetElement = document.elementFromPoint(touch.pageX - window.pageXOffset, touch.pageY - window.pageYOffset);
+		// In certain cases arguments of elementFromPoint can be negative, so prevent setting targetElement to null
+		targetElement = document.elementFromPoint(touch.pageX - window.pageXOffset, touch.pageY - window.pageYOffset) || targetElement;
 	}
 
 	targetTagName = targetElement.tagName.toLowerCase();


### PR DESCRIPTION
Fix for regression introduced by fix for #57. In certain edge cases (noticed when scrolling down) the second argument of `document.elementFromPoint` can be negative, which causes NRE here: https://github.com/ftlabs/fastclick/blob/master/lib/fastclick.js#L505

So I'd suggest the fallback to original targetElement here.

Unfortunately I cannot provide a good test for it since I was not able to reproduce it in 100% cases. The issue is reproduced intermittently on pages with multiple `<input>` elements.
