### PR TITLE
Keep bower.json file in the project

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,8 @@
   "main": "lib/fastclick.js",
   "ignore": [
     "**/.*",
-    "*.json",
+    "component.json",
+    "package.json",
     "Makefile",
     "tests",
     "examples"


### PR DESCRIPTION
I think it is a good idea to keep bower.json in the project folder because when using bower to retrieve your package, you might want this file in order to build the whole stuff.

In my case, I need the 'main' property to be able to reference the file.

Bower states that main lists "The primary endpoints of your package". I think it is important to be able to access them.
