### PR TITLE
Ignore clicks that also involve a page scroll of more than 10 pixels in ...

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -384,6 +384,8 @@ FastClick.prototype.onTouchStart = function(event) {
 
 	this.touchStartX = touch.pageX;
 	this.touchStartY = touch.pageY;
+	this.scrollX = window.scrollX || window.pageXOffset;
+	this.scrollY = window.scrollY || window.pageYOffset;
 
 	// Prevent phantom clicks on fast double-tap (issue #36)
 	if ((event.timeStamp - this.lastClickTime) < 200) {
@@ -410,6 +412,22 @@ FastClick.prototype.touchHasMoved = function(event) {
 
 	return false;
 };
+
+
+/**
+ * Use the window to check if the document has scrolled beyond a certain threshold.
+ *
+ * Threshold is 10 pixels in-line with touchHasMoved
+ */
+FastClick.prototype.pageHasScrolled = function() {
+	'use strict';
+
+	if (Math.abs(window.scrollY - this.scrollY) > 10 || Math.abs(window.scrollX - this.scrollX) > 10) {
+		return true;
+	}
+
+	return false;
+}
 
 
 /**
@@ -448,7 +466,7 @@ FastClick.prototype.onTouchEnd = function(event) {
 	var forElement, trackingClickStart, targetTagName, scrollParent, touch, targetElement = this.targetElement;
 
 	// If the touch has moved, cancel the click tracking
-	if (this.touchHasMoved(event)) {
+	if (this.touchHasMoved(event) || this.pageHasScrolled()) {
 		this.trackingClick = false;
 		this.targetElement = null;
 	}


### PR DESCRIPTION
...any direction.

Scrolling the page but finishing the scroll with your finger in the same page-relative position as when you started results in a click. For link-heavy pages this makes it impossible to scroll.
