### PR TITLE
When double click, no longer cancels following input click on iOS

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -506,7 +506,10 @@ FastClick.prototype.onTouchEnd = function(event) {
 	if ((event.timeStamp - this.lastClickTime) < 200) {
 		this.cancelNextClick = true;
 		return true;
-	}
+	} else {
+        //reset to prevent wrong click cancel on input (issue #156)
+        this.cancelNextClick = false;
+    }
 
 	this.lastClickTime = event.timeStamp;
 


### PR DESCRIPTION
fixes #156
