### PR TITLE
Fix for selects on Android Chrome

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -245,8 +245,9 @@ FastClick.prototype.needsFocus = function(target) {
 	'use strict';
 	switch (target.nodeName.toLowerCase()) {
 	case 'textarea':
-	case 'select':
 		return true;
+	case 'select':
+		return !this.deviceIsAndroid;
 	case 'input':
 		switch (target.type) {
 		case 'button':
@@ -285,10 +286,21 @@ FastClick.prototype.sendClick = function(targetElement, event) {
 
 	// Synthesise a click event, with an extra attribute so it can be tracked
 	clickEvent = document.createEvent('MouseEvents');
-	clickEvent.initMouseEvent('click', true, true, window, 1, touch.screenX, touch.screenY, touch.clientX, touch.clientY, false, false, false, false, 0, null);
+	clickEvent.initMouseEvent(this.determineEventType(targetElement), true, true, window, 1, touch.screenX, touch.screenY, touch.clientX, touch.clientY, false, false, false, false, 0, null);
 	clickEvent.forwardedTouchEvent = true;
 	targetElement.dispatchEvent(clickEvent);
 };
+
+FastClick.prototype.determineEventType = function(targetElement) {
+	'use strict;'
+
+	//Issue #159: Android Chrome Select Box does not open with a synthetic click event
+	if (this.deviceIsAndroid && targetElement.tagName.toLowerCase() === 'select') {
+		return 'mousedown';
+	}
+
+	return 'click';
+}
 
 
 /**


### PR DESCRIPTION
This fixes #159. If on Android Chrome then a mousedown event should be triggered instead of a click event to open the options menu. It does not need focus set on the select element either.

The solution is inspired by this [StackOverflow answer](http://stackoverflow.com/a/10136523/22688).

I have tested this with the Android browser on Android versions 2.2, 2.3 and 4.0.4.  I have tested it on Chrome on Android versions 4.0.4 and 4.2. And double checked that it works on Iphone 3 and 4, Ipad (Safari and Chrome) and Windows Phone 8.

As there are no unit tests I'm not totally sure I've covered all the edge cases, how do you usually handle testing? Let me know if there is anything strange or if any changes need to be made.
