### PR TITLE
Chrome >= 32 removes 300ms delay on pages that are device-width or less

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ The library has been deployed as part of the [FT Web App](http://app.ft.com/) an
 
 ## When it isn't needed ##
 
-FastClick doesn't attach any listeners on desktop browsers or Chrome on Android with `user-scalable=no` in the [viewport meta tag](https://developer.mozilla.org/en-US/docs/Mobile/Viewport_meta_tag) as it is not needed. You should add this tag if you want to disable double-tap-to-zoom entirely.
+FastClick doesn't attach any listeners on desktop browsers.
+
+Chrome 32+ on Android with `width=device-width` in the [viewport meta tag](https://developer.mozilla.org/en-US/docs/Mobile/Viewport_meta_tag) doesn't have a 300ms delay, therefore listeners aren't attached.
+
+Same goes for Chrome on Android (all versions) with `user-scalable=no` in the viewport meta tag. But be aware that `user-scalable=no` also disables pinch zooming, which may be an accessibility concern.
 
 ```html
 <meta name="viewport" content="initial-scale=1.0, user-scalable=no">

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -721,19 +721,30 @@ FastClick.prototype.destroy = function() {
 FastClick.notNeeded = function(layer) {
 	'use strict';
 	var metaViewport;
+	var chromeVersion;
 
 	// Devices that don't support touch don't need FastClick
 	if (typeof window.ontouchstart === 'undefined') {
 		return true;
 	}
 
-	if ((/Chrome\/[0-9]+/).test(navigator.userAgent)) {
+	// Chrome version - zero for other browsers
+	chromeVersion = +(/Chrome\/([0-9]+)/.exec(navigator.userAgent) || [,0])[1];
 
-		// Chrome on Android with user-scalable="no" doesn't need FastClick (issue #89)
+	if (chromeVersion) {
+
 		if (FastClick.prototype.deviceIsAndroid) {
 			metaViewport = document.querySelector('meta[name=viewport]');
-			if (metaViewport && metaViewport.content.indexOf('user-scalable=no') !== -1) {
-				return true;
+			
+			if (metaViewport) {
+				// Chrome on Android with user-scalable="no" doesn't need FastClick (issue #89)
+				if (metaViewport.content.indexOf('user-scalable=no') !== -1) {
+					return true;
+				}
+				// Chrome 32 and above with width=device-width or less don't need FastClick
+				if (chromeVersion > 31 && window.innerWidth <= window.screen.width) {
+					return true;
+				}
 			}
 
 		// Chrome desktop doesn't need FastClick (issue #15)


### PR DESCRIPTION
Chrome 32 should go into beta later this month - happy for you to wait until it's released to do your own testing before merging, but it's doing the right thing on internal builds.

Here's the Chrome change https://codereview.chromium.org/18850005/
