### PR TITLE
Update examples to only disable tap-to-zoom (keep pinchzooming working).

### DIFF
--- a/examples/focus.html
+++ b/examples/focus.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> 
 <html> 
 <head> 
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"> 
+<meta name="viewport" content="width=device-width, initial-scale=1"> 
 <style type="text/css"> 
 	p, .test { font-family: sans-serif; }
 	.test { margin: 1em 4em; line-height: 4em; border: 1px solid black; font-size: 2em; text-align: center; }

--- a/examples/input.html
+++ b/examples/input.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> 
 <html> 
 <head> 
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"> 
+<meta name="viewport" content="width=device-width, initial-scale=1"> 
 <style type="text/css"> 
 	p, label { font-family: sans-serif; }
 	.test { text-align: center; }

--- a/examples/layer.html
+++ b/examples/layer.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <style type="text/css">
 	p, .test { font-family: sans-serif; }
 	.test { margin: 1em auto; width: 6em; line-height: 4em; border: 1px solid black; font-size: 2em; text-align: center; }


### PR DESCRIPTION
Many of the arguments about accessibility base on the incorrect assumption that in order to have faster clicks you need to disable pinch zoom.  (You only need to disable tap to zoom)

I think we should update the examples so that you can pinch zoom them.
