### PR TITLE
Allow touch-focusing on read-only text boxes if marked with "needsfocus"

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -243,6 +243,9 @@ FastClick.prototype.needsClick = function(target) {
  */
 FastClick.prototype.needsFocus = function(target) {
 	'use strict';
+	if( (/\bneedsfocus\b/).test(target.className) )
+		return true;
+		
 	switch (target.nodeName.toLowerCase()) {
 	case 'textarea':
 		return true;
@@ -262,7 +265,7 @@ FastClick.prototype.needsFocus = function(target) {
 		// No point in attempting to focus disabled inputs
 		return !target.disabled && !target.readOnly;
 	default:
-		return (/\bneedsfocus\b/).test(target.className);
+		return false;
 	}
 };
 


### PR DESCRIPTION
If a read-only text box is part of a complex widget, it may be desirable to touch-focus on it. Checking className ahead of the type/state of control should not break existing behavior except in the case where "needsfocus" is used for unrelated purposes.
