### PR TITLE
	Allow touch-focusing on read-only text boxes if marked with "needsfocus"

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -243,6 +243,9 @@ FastClick.prototype.needsClick = function(target) {
  */
 FastClick.prototype.needsFocus = function(target) {
 	'use strict';
+	if( (/\bneedsfocus\b/).test(target.className) )
+		return true;
+		
 	switch (target.nodeName.toLowerCase()) {
 	case 'textarea':
 		return true;
@@ -262,7 +265,7 @@ FastClick.prototype.needsFocus = function(target) {
 		// No point in attempting to focus disabled inputs
 		return !target.disabled && !target.readOnly;
 	default:
-		return (/\bneedsfocus\b/).test(target.className);
+		return false;
 	}
 };
 

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -314,7 +314,7 @@ FastClick.prototype.focus = function(targetElement) {
 	var length;
 
 	// Issue #160: on iOS 7, some input elements (e.g. date datetime) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
-	if (this.deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time') {
+	if (this.deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && !(targetElement.disabled || targetElement.readOnly)) {
 		length = targetElement.value.length;
 		targetElement.setSelectionRange(length, length);
 	} else {


### PR DESCRIPTION
If a read-only text box is part of a complex widget, it may be desirable to touch-focus on it. Checking className ahead of the type/state of control should not break existing behavior except in the case where "needsfocus" is used for unrelated purposes.
