### PR TITLE
Fix needsclick class check on SVG elements

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -231,7 +231,8 @@ FastClick.prototype.needsClick = function(target) {
 		return true;
 	}
 
-	return (/\bneedsclick\b/).test(target.className);
+	return (/\bneedsclick\b/).test(target.className) ||
+		(/\bneedsclick\b/).test(target.className.baseVal);
 };
 
 


### PR DESCRIPTION
`className` property on SVG elements is an instance of `SVGAnimatedString`, so the needsclick check, which expects `className` to be a string, fails on SVG elements.

https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimatedString
