### PR TITLE
Disable fastclick on elements with contenteditable=true (related to issue #127)

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -387,7 +387,7 @@ FastClick.prototype.onTouchStart = function(event) {
 	targetElement = this.getTargetElementFromEventTarget(event.target);
 	touch = event.targetTouches[0];
 
-	// Ignore touches on contenteditable elements to prevent conflict with text selection.
+	// Ignore touches on contenteditable elements to prevent conflict with text selection (issue #127).
 	if (targetElement.isContentEditable) {
 		return true;
 	}

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -387,6 +387,11 @@ FastClick.prototype.onTouchStart = function(event) {
 	targetElement = this.getTargetElementFromEventTarget(event.target);
 	touch = event.targetTouches[0];
 
+  // Ignore touches on contenteditable elements to prevent conflict with text selection.
+  if (targetElement.isContentEditable) {
+    return true;
+  }
+
 	if (this.deviceIsIOS) {
 
 		// Only trusted events will deselect text on iOS (issue #49)

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -387,10 +387,10 @@ FastClick.prototype.onTouchStart = function(event) {
 	targetElement = this.getTargetElementFromEventTarget(event.target);
 	touch = event.targetTouches[0];
 
-  // Ignore touches on contenteditable elements to prevent conflict with text selection.
-  if (targetElement.isContentEditable) {
-    return true;
-  }
+	// Ignore touches on contenteditable elements to prevent conflict with text selection.
+	if (targetElement.isContentEditable) {
+		return true;
+	}
 
 	if (this.deviceIsIOS) {
 


### PR DESCRIPTION
This patch addresses the issues reported in Issue #127 for contenteditable=true elements.  There may be a more generally applicable solution for other kinds of inputs but this solution has worked well for me with the Redactor WYSIWYG editor.
