### PR TITLE
Small tidy up

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -90,8 +90,8 @@ function FastClick(layer) {
 	}
 
 	// Some old versions of Android don't have Function.prototype.bind
-	function bind(fn, scope) {
-		return function() { return fn.apply(scope, arguments); };
+	function bind(method, context) {
+		return function() { return method.apply(context, arguments); };
 	}
 
 	// Set up event handlers as required


### PR DESCRIPTION
- Tidy up the way scope is managed.
- Remove the check for whether the layer is a DOM node (there are [valid use cases](https://github.com/matthew-andrews/selective-fastclick/) where it might not be).
- Use local variables for device checks.
- Whitespace.
