### PR TITLE
noting that AMD style require returns FastClick not FastClick.attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,12 @@ Run `make` to build a minified version of FastClick using the Closure Compiler R
 
 ### AMD ###
 
-FastClick has AMD (Asynchronous Module Definition) support. This allows it to be lazy-loaded with an AMD loader, such as [RequireJS](http://requirejs.org/).
+FastClick has AMD (Asynchronous Module Definition) support. This allows it to be lazy-loaded with an AMD loader, such as [RequireJS](http://requirejs.org/). Note that when using the AMD style require, the full `FastClick` object will be returned, _not_ `FastClick.attach`
+
+```js
+var FastClick = require('fastclick');
+FastClick.attach(document.body);
+```
 
 ### Package managers ###
 


### PR DESCRIPTION
I was confused for a bit because I wrongly assumed that the AMD require would return `FastClick.attach`, so I've added a note to the readme.
