### PR TITLE
Fix for horizontal scroll on iOS

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -332,6 +332,7 @@ FastClick.prototype.updateScrollParent = function(targetElement) {
 	// Always update the scroll top tracker if possible.
 	if (scrollParent) {
 		scrollParent.fastClickLastScrollTop = scrollParent.scrollTop;
+        	scrollParent.fastClickLastScrollLeft = scrollParent.scrollLeft;
 	}
 };
 
@@ -561,7 +562,7 @@ FastClick.prototype.onTouchEnd = function(event) {
 		// Don't send a synthetic click event if the target element is contained within a parent layer that was scrolled
 		// and this tap is being used to stop the scrolling (usually initiated by a fling - issue #42).
 		scrollParent = targetElement.fastClickScrollParent;
-		if (scrollParent && scrollParent.fastClickLastScrollTop !== scrollParent.scrollTop) {
+		if (scrollParent && (scrollParent.fastClickLastScrollTop !== scrollParent.scrollTop || scrollParent.fastClickLastScrollLeft !== scrollParent.scrollLeft)) {
 			return true;
 		}
 	}


### PR DESCRIPTION
The same check needs to be in place for horizontal scroll as vertical scrolling.
