### PR TITLE
TypeError: 'null' is not an object (evaluating 'g.tagName')

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -523,7 +523,13 @@ FastClick.prototype.onTouchEnd = function(event) {
 		targetElement = document.elementFromPoint(touch.pageX - window.pageXOffset, touch.pageY - window.pageYOffset) || targetElement;
 		targetElement.fastClickScrollParent = this.targetElement.fastClickScrollParent;
 	}
-
+	
+	if(targetElement && tagName) {
+		targetTagName = targetElement.tagName.toLowerCase();
+  	} else {
+		targetTagName = '';
+	}
+	
 	targetTagName = targetElement.tagName.toLowerCase();
 	if (targetTagName === 'label') {
 		forElement = this.findControl(targetElement);


### PR DESCRIPTION
`TypeError: 'null' is not an object (evaluating 'g.tagName')`

It was throwing above exception in our min file at this particular location.
