### PR TITLE
iPhone 5 users not able to tap

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -385,10 +385,10 @@ FastClick.prototype.onTouchStart = function(event) {
 			// with the same identifier as the touch event that previously triggered the click that triggered the alert.
 			// Sadly, there is an issue on iOS 4 that causes some normal touch events to have the same identifier as an
 			// immediately preceeding touch event (issue #52), so this fix is unavailable on that platform.
-			if (touch.identifier === this.lastTouchIdentifier) {
-				event.preventDefault();
-				return false;
-			}
+			// if (touch.identifier === this.lastTouchIdentifier) {
+			// 	event.preventDefault();
+			//    	return false;
+			// }
 
 			this.lastTouchIdentifier = touch.identifier;
 


### PR DESCRIPTION
Commenting these lines seems to fix an issue we had with our iPhone5 customers where they are not able to tap/click on buttons/textboxes but they can submit using keypad Go button.
https://github.com/ftlabs/fastclick/blob/master/lib/fastclick.js#L388-L391

It might have some adverse behaviour, but not sure what it would be.

Also to note that it has surprisingly came up today when many of our customers reported it when the same code is in production from long time. Might be that Apple/webkit has released an update.
