### PR TITLE
Fix explanation of when focusing is allowed

### DIFF
--- a/examples/focus.html
+++ b/examples/focus.html
@@ -27,7 +27,7 @@
 <body> 
 	<p>FastClick is instantiated on the body element, so all visible elements on this page will receive fast clicks - except one.</p> 
 	<p>The layers marked <var>A</var> and <var>B</var> both have <code>click</code> handlers that will attempt to trigger focus on the <code>input</code> element programatically. However, <strong>on iOS before version 5.0</strong>, touch event handlers are not allowed to trigger focus on other elements.</p> 
-	<p>On earlier versions of iOS, only <var>B</var> will succeed at triggering focus on the input element, because it has a <code>needsclick</code> class which will instruct FastClick not to trigger a programmatic click in the touch event handler and let the system click event go through instread.</p> 
+	<p>On earlier versions of iOS, only <var>B</var> will succeed at triggering focus on the input element, because it has a <code>needsclick</code> class which will instruct FastClick not to trigger a programmatic click in the touch event handler and let the system click event go through instead.</p> 
 	<div>
 		<input type="text">
 		<div class="test">A</div> 


### PR DESCRIPTION
Nitpick, but triggering programmatic events calls event handlers
synchronously, and can focus things fine, the problem demonstrated in
this example page is that (in Safari on iOS < 5) touchend event handlers
just can't focus things. Here's a page with more discriminatory test
cases:
http://jsbin.com/gixaduni/2
