### PR TITLE
Fix destroy method by storing references to bound listeners

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -103,18 +103,32 @@ function FastClick(layer, options) {
 		return function() { return method.apply(context, arguments); };
 	}
 
-	// Set up event handlers as required
-	if (deviceIsAndroid) {
-		layer.addEventListener('mouseover', bind(this.onMouse, this), true);
-		layer.addEventListener('mousedown', bind(this.onMouse, this), true);
-		layer.addEventListener('mouseup', bind(this.onMouse, this), true);
+	// Bind the specified functions to the context (adapted from Underscore)
+	function bindAll(context) {
+		var methods = Array.prototype.slice.call(arguments, 1);
+		if (!methods.length) {
+			return;
+		}
+		for (var i = 0, ilen = methods.length, method; i < ilen; i++, method = methods[i]) {
+			context[method] = bind(context[method], context);
+		}
+		return context;
 	}
 
-	layer.addEventListener('click', bind(this.onClick, this), true);
-	layer.addEventListener('touchstart', bind(this.onTouchStart, this), false);
-	layer.addEventListener('touchmove', bind(this.onTouchMove, this), false);
-	layer.addEventListener('touchend', bind(this.onTouchEnd, this), false);
-	layer.addEventListener('touchcancel', bind(this.onTouchCancel, this), false);
+	bindAll(this, 'onMouse', 'onClick', 'onTouchStart', 'onTouchMove', 'onTouchEnd', 'onTouchCancel');
+
+	// Set up event handlers as required
+	if (deviceIsAndroid) {
+		layer.addEventListener('mouseover', this.onMouse, true);
+		layer.addEventListener('mousedown', this.onMouse, true);
+		layer.addEventListener('mouseup', this.onMouse, true);
+	}
+
+	layer.addEventListener('click', this.onClick, true);
+	layer.addEventListener('touchstart', this.onTouchStart, false);
+	layer.addEventListener('touchmove', this.onTouchMove, false);
+	layer.addEventListener('touchend', this.onTouchEnd, false);
+	layer.addEventListener('touchcancel', this.onTouchCancel, false);
 
 	// Hack is required for browsers that don't support Event#stopImmediatePropagation (e.g. Android 2)
 	// which is how FastClick normally stops click events bubbling to callbacks registered on the FastClick


### PR DESCRIPTION
Fixes #236

The issue here was that added event listeners didn't match the ones `destroy()` attempts to remove, because no reference is stored to the methods after `bind()` is called on them.

(The Underscore-like solution felt like a clean way of handling this, as many are already familiar with the "bindAll" vocabulary.)
