### PR TITLE
Add link to pre-minified FastClick - hopefully addressing #192

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ attachFastClick(document.body);
 
 ### Minified ###
 
-Run `make` to build a minified version of FastClick using the Closure Compiler REST API. The minified file is saved to `build/fastclick.min.js`.
+Run `make` to build a minified version of FastClick using the Closure Compiler REST API. The minified file is saved to `build/fastclick.min.js` or you can [download a pre-minified version](http://build.origami.ft.com/bundles/js?modules=fastclick).
 
 ### AMD ###
 


### PR DESCRIPTION
@2ix, @mlms13 - I know you ideally wanted a pre-minified version of the code committed into the repository but within FT Labs we feel that this isn't something we want to do - and the other open source repositories we have that have committed built/minified bundles will have those files phased out...

I've added a link to [a minified version of FastClick](http://build.origami.ft.com/bundles/js?modules=fastclick) on the readme, which will be automatically updated whenever we publish a new version.  I hope this will be acceptable compromise.
