### PR TITLE
Fixed text field behavior on iOS

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -199,6 +199,22 @@ var deviceIsIOSWithBadTarget = deviceIsIOS && (/OS ([6-9]|\d{2})_\d/).test(navig
 
 
 /**
+ * Valid types for text inputs
+ *
+ * @type array
+ */
+var textFields = [
+  'email'
+, 'number'
+, 'password'
+, 'search'
+, 'tel'
+, 'text'
+, 'url'
+];
+
+
+/**
  * Determine whether a given element requires a native click.
  *
  * @param {EventTarget|Element} target Target DOM element
@@ -369,6 +385,18 @@ FastClick.prototype.getTargetElementFromEventTarget = function(eventTarget) {
 
 
 /**
+ * @param {EventTarget} targetElement
+ * @returns {boolean}
+ */
+FastClick.prototype.isTextField = function(targetElement) {
+	return (
+	  targetElement.tagName.toLowerCase() === 'textarea'
+	  || textFields.indexOf(targetElement.type) !== -1
+	);
+};
+
+
+/**
  * On touch start, record the position and scroll offset.
  *
  * @param {Event} event
@@ -388,11 +416,19 @@ FastClick.prototype.onTouchStart = function(event) {
 
 	if (deviceIsIOS) {
 
+    // Ignore touchstart in focused text field
+    // Allows normal text selection and commands (select/paste/cut) when a field has focus, while still allowing fast tap-to-focus.
+    // Without this fix, user needs to tap-and-hold a text field for context menu, and double-tap to select text doesn't work at all.
+    if (targetElement === document.activeElement && this.isTextField(targetElement)) {
+      return true;
+    }
+
 		// Only trusted events will deselect text on iOS (issue #49)
-		selection = window.getSelection();
-		if (selection.rangeCount && !selection.isCollapsed) {
-			return true;
-		}
+    // This should no longer be needed with the above fix in place
+// 		selection = window.getSelection();
+// 		if (selection.rangeCount && !selection.isCollapsed) {
+// 			return true;
+// 		}
 
 		if (!deviceIsIOS4) {
 


### PR DESCRIPTION
On iOS, FastClick now ignores touchstart events on focused text fields.
This resolves multiple issues: double-tap to select works (was
completely broken); single-tap reliably deselects text; and single-tap
brings up context menu (previously had to tap-and-hold).
