### PR TITLE
Updated notNeeded for BlackBerry 10.3+

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -767,7 +767,18 @@ FastClick.notNeeded = function(layer) {
 		// BlackBerry 10.3+ does not require Fastclick library.
 		// https://github.com/ftlabs/fastclick/issues/251
 		if (blackberryVersion[1] >= 10 && blackberryVersion[2] >= 3) {
-			return true;
+			metaViewport = document.querySelector('meta[name=viewport]');
+
+			if (metaViewport) {
+				// user-scalable=no eliminates click delay.
+				if (metaViewport.content.indexOf('user-scalable=no') !== -1) {
+					return true;
+				}
+				// width=device-width (or less than device-width) eliminates click delay.
+				if (document.documentElement.scrollWidth <= window.outerWidth) {
+					return true;
+				}
+			}
 		}
 	}
 	


### PR DESCRIPTION
Added exception for BlackBerry 10.3+.
