### PR TITLE
Added Firefox 27+ to the "notNeeded" browsers 

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -762,7 +762,7 @@ FastClick.notNeeded = function(layer) {
 		// Firefox 27+ does not have tap delay if the content is not zoomable - https://bugzilla.mozilla.org/show_bug.cgi?id=922896
 
 		metaViewport = document.querySelector('meta[name=viewport]');
-		if (metaViewport && metaViewport.content.indexOf('user-scalable=no') !== -1) {
+		if (metaViewport && (metaViewport.content.indexOf('user-scalable=no') !== -1 || document.documentElement.scrollWidth <= window.outerWidth)) {
 			return true;
 		}
 	}

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -723,6 +723,7 @@ FastClick.notNeeded = function(layer) {
 	'use strict';
 	var metaViewport;
 	var chromeVersion;
+	var firefoxVersion;
 
 	// Devices that don't support touch don't need FastClick
 	if (typeof window.ontouchstart === 'undefined') {
@@ -750,6 +751,18 @@ FastClick.notNeeded = function(layer) {
 
 		// Chrome desktop doesn't need FastClick (issue #15)
 		} else {
+			return true;
+		}
+	}
+
+	// Firefox version - zero for other browsers
+	firefoxVersion = +(/Firefox\/([0-9]+)/.exec(navigator.userAgent) || [,0])[1];
+
+	if (firefoxVersion >= 27) {
+		// Firefox 27+ does not have tap delay if the content is not zoomable - https://bugzilla.mozilla.org/show_bug.cgi?id=922896
+
+		metaViewport = document.querySelector('meta[name=viewport]');
+		if (metaViewport && metaViewport.content.indexOf('user-scalable=no') !== -1) {
 			return true;
 		}
 	}


### PR DESCRIPTION
It does not have a tap delay when the content is not zoomable. More details in this bug - [https://bugzilla.mozilla.org/show_bug.cgi?id=922896](https://bugzilla.mozilla.org/show_bug.cgi?id=922896)

I have tested it with Geeksphone Keon running FirefoxOS 1.4 and Firefox version 30.