### PR TITLE
Fix touching elements nested inside labels

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -569,7 +569,7 @@ FastClick.prototype.onTouchEnd = function(event) {
 	if (targetLabel !== null) {
 		forElement = this.findControl(targetLabel);
 		if (forElement) {
-			this.focus(targetElement);
+			this.focus(targetLabel);
 			if (deviceIsAndroid) {
 				return false;
 			}

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -504,6 +504,25 @@ FastClick.prototype.findControl = function(labelElement) {
 	return labelElement.querySelector('button, input:not([type=hidden]), keygen, meter, output, progress, select, textarea');
 };
 
+/**
+ * Attempt to find the label which the target element is nested within.
+ *
+ * @param {HTMLElement} targetElement
+ * @returns {HTMLLabelElement|null}
+ */
+FastClick.prototype.getLabel = function(targetElement) {
+	'use strict';
+	var candidate = targetElement;
+	while (candidate !== void(0) && candidate !== null) {
+		if (candidate.tagName.toLowerCase() === 'label') {
+			return candidate;
+		}
+
+		candidate = candidate.parentElement;
+	}
+
+	return null;
+};
 
 /**
  * On touch end, determine whether to send a click event at once.
@@ -513,7 +532,7 @@ FastClick.prototype.findControl = function(labelElement) {
  */
 FastClick.prototype.onTouchEnd = function(event) {
 	'use strict';
-	var forElement, trackingClickStart, targetTagName, scrollParent, touch, targetElement = this.targetElement;
+	var forElement, trackingClickStart, targetLabel, scrollParent, touch, targetElement = this.targetElement;
 
 	if (!this.trackingClick) {
 		return true;
@@ -546,9 +565,9 @@ FastClick.prototype.onTouchEnd = function(event) {
 		targetElement.fastClickScrollParent = this.targetElement.fastClickScrollParent;
 	}
 
-	targetTagName = targetElement.tagName.toLowerCase();
-	if (targetTagName === 'label') {
-		forElement = this.findControl(targetElement);
+	targetLabel = this.getLabel(targetElement);
+	if (targetLabel !== null) {
+		forElement = this.findControl(targetLabel);
 		if (forElement) {
 			this.focus(targetElement);
 			if (deviceIsAndroid) {
@@ -561,7 +580,7 @@ FastClick.prototype.onTouchEnd = function(event) {
 
 		// Case 1: If the touch started a while ago (best guess is 100ms based on tests for issue #36) then focus will be triggered anyway. Return early and unset the target element reference so that the subsequent click will be allowed through.
 		// Case 2: Without this exception for input elements tapped when the document is contained in an iframe, then any inputted text won't be visible even though the value attribute is updated as the user types (issue #37).
-		if ((event.timeStamp - trackingClickStart) > 100 || (deviceIsIOS && window.top !== window && targetTagName === 'input')) {
+		if ((event.timeStamp - trackingClickStart) > 100 || (deviceIsIOS && window.top !== window && targetLabel !== null)) {
 			this.targetElement = null;
 			return false;
 		}
@@ -571,7 +590,7 @@ FastClick.prototype.onTouchEnd = function(event) {
 
 		// Select elements need the event to go through on iOS 4, otherwise the selector menu won't open.
 		// Also this breaks opening selects when VoiceOver is active on iOS6, iOS7 (and possibly others)
-		if (!deviceIsIOS || targetTagName !== 'select') {
+		if (!deviceIsIOS || targetElement.tagName.toLowerCase() !== 'select') {
 			this.targetElement = null;
 			event.preventDefault();
 		}


### PR DESCRIPTION
Rather than only checking if the touched element itself is a label,
check parent elements recursively to see if the touched element is
sitting within a label.
