### PR TITLE
Fast click masks taphold events if the same element is listening to click event as well 

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -93,6 +93,8 @@ function FastClick(layer, options) {
 	 * @type number
 	 */
 	this.tapDelay = options.tapDelay || 200;
+	
+	this.tapMaxDelay = options.tapMaxDelay || 1000;
 
 	if (FastClick.notNeeded(layer)) {
 		return;
@@ -520,7 +522,8 @@ FastClick.prototype.onTouchEnd = function(event) {
 	}
 
 	// Prevent phantom clicks on fast double-tap (issue #36)
-	if ((event.timeStamp - this.lastClickTime) < this.tapDelay) {
+	var eventDelay = event.timeStamp - this.lastClickTime;
+	if (eventDelay < this.tapDelay && this.tapMaxDelay > eventDelay) {
 		this.cancelNextClick = true;
 		return true;
 	}

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -523,7 +523,7 @@ FastClick.prototype.onTouchEnd = function(event) {
 
 	// Prevent phantom clicks on fast double-tap (issue #36)
 	var eventDelay = event.timeStamp - this.lastClickTime;
-	if (eventDelay < this.tapDelay && this.tapMaxDelay > eventDelay) {
+	if (eventDelay < this.tapDelay ||  eventDelay > this.tapMaxDelay) {
 		this.cancelNextClick = true;
 		return true;
 	}

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -94,7 +94,7 @@ function FastClick(layer, options) {
 	 */
 	this.tapDelay = options.tapDelay || 200;
 	
-	this.tapMaxDelay = options.tapMaxDelay || 1000;
+	this.tapMaxDelay = options.tapMaxDelay || 2000;
 
 	if (FastClick.notNeeded(layer)) {
 		return;


### PR DESCRIPTION
When an element is configured to listen to both click and taphold events, fast click is masking the later event which is resulting in triggering only click event.

I have introduced a new parameter in options - tapMaxDelay.  On touchEnd if the event delay is more than tapMaxDelay we are canceling the event.

I have noticed it on Android Emulator, I think behavior should be same across all the devices.

I'm unsure if the issue to be taken care by registering taphold event and cancel next click flag (not sure about the compatibility of taphold. I have worked only with android). 
