### PR TITLE
Avoid TypeError on tapping range elements

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -316,7 +316,7 @@ FastClick.prototype.focus = function(targetElement) {
 	var length;
 
 	// Issue #160: on iOS 7, some input elements (e.g. date datetime) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
-	if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time') {
+	if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'range') {
 		length = targetElement.value.length;
 		targetElement.setSelectionRange(length, length);
 	} else {


### PR DESCRIPTION
It appears the issue related to https://github.com/ftlabs/fastclick/issues/160 also affects range elements.
I'm not terribly familiar with the fastclick code, but this error is ****ing me in production right now.
Thoughts?
