### PR TITLE
Test the validity of the  property this.targetElement in onTouchEnd function

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,4 @@
-{
+{ 
   "name": "fastclick",
   "main": "lib/fastclick.js",
   "ignore": [

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -521,6 +521,11 @@
 	FastClick.prototype.onTouchEnd = function(event) {
 		var forElement, trackingClickStart, targetTagName, scrollParent, touch, targetElement = this.targetElement;
 
+		if (this.targetElement !== this.getTargetElementFromEventTarget(event.target)) {
+			this.trackingClick = false;
+			this.targetElement = null;
+		}
+
 		if (!this.trackingClick) {
 			return true;
 		}


### PR DESCRIPTION
If, for some reasons, the touchstart event is stopped by some third party library but not the touchend event, the value of this.targetElement is out of date. This commit add a test to verify if the current element is the good one.

Hope I'm clear.
