### PR TITLE
Update README.md with a working AMD example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ FastClick has AMD (Asynchronous Module Definition) support. This allows it to be
 
 ```js
 var FastClick = require('fastclick');
-FastClick.attach(document.body);
+FastClick(document.body, options);
 ```
 
 ### Package managers ###


### PR DESCRIPTION
Using FastClick with AMD as the example shows does not work:

``` js
 var FastClick = require('fastclick');
FastClick.attach(document.body);
```

So I updated it with a working example:

``` js
 var FastClick = require('fastclick');
FastClick(document.body, options);
```
