### PR TITLE
Issue 146 Ghostclick on android with dynamic content

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -110,7 +110,6 @@ function FastClick(layer, options) {
 	 */
 	this.setClickedNowTimestamp = options.setClickedNowTimestamp || function(ts) {
 		document._fsLastClicked = ts;
-		console.log("last clicked set to " + ts);
 	};
 
 	/**
@@ -126,7 +125,6 @@ function FastClick(layer, options) {
 			document._fsLastClicked = 0;
 		}
 
-		console.log("getting last clicked of " + document._fsLastClicked);	
 		return document._fsLastClicked;
 	};
 
@@ -699,7 +697,6 @@ FastClick.prototype.onMouse = function(event) {
 
 	// Ghost clicks don't present as anything other that a click really soon after the previous click
 	if (deviceIsGhostClickAfflicted && this.isGhostClick()) {
-		console.log("STOP")
 		return stopEvent(event);
 	}
 
@@ -742,13 +739,10 @@ FastClick.prototype.clickedNow = function() {
  * @type boolean
  */ 
 FastClick.prototype.isGhostClick = function() {
-	console.log("yep checking for ghosts")
 	if(this.getClickedNowTimestamp) {
-		console.log("isGhostClick:" + (new Date().getTime() - this.getClickedNowTimestamp()) + " and threshold is " + this.ghostClickTapDelay);
 			
 		if(new Date().getTime() - this.getClickedNowTimestamp() < this.ghostClickTapDelay) {
 			
-			console.log("ITS A GHOST");
 			return true;
 		}
 	}
@@ -780,8 +774,7 @@ FastClick.prototype.onClick = function(event) {
 	}
 
 	permitted = this.onMouse(event);
-	console.log("PERMITTED:" + permitted);
-
+	
 	// Only unset targetElement if the click is not permitted. This will ensure that the check for !targetElement in onMouse fails and the browser's click doesn't go through.
 	if (!permitted) {
 		this.targetElement = null;

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -94,6 +94,49 @@ function FastClick(layer, options) {
 	 */
 	this.tapDelay = options.tapDelay || 200;
 
+	/**
+	 * Option to force ghost click checking
+	 *
+	 * @type boolean
+	 */
+	this.enableGhostClickCheck = options.enableGhostClickCheck || false;
+
+	/**
+	 * The function to store the last clicked timestamp
+	 * The property that holds the timestamp should be globally available,
+	 * and configured on any other instances of FastClick
+	 *
+	 * @type function
+	 */
+	this.setClickedNowTimestamp = options.setClickedNowTimestamp || function(ts) {
+		document._fsLastClicked = ts;
+		console.log("last clicked set to " + ts);
+	};
+
+	/**
+	 * The function to get the last clicked timestamp
+	 * The property that holds the timestamp should be globally available,
+	 * and configured on any other instances of FastClick
+	 *
+	 * @type function
+	 */
+	this.getClickedNowTimestamp = options.getClickedNowTimestamp || function() {
+
+		if(!document._fsLastClicked) {
+			document._fsLastClicked = 0;
+		}
+
+		console.log("getting last clicked of " + document._fsLastClicked);	
+		return document._fsLastClicked;
+	};
+
+	/**
+	 * The minimum time between click events to detect ghost clicks
+	 *
+	 * @type number
+	 */
+	this.ghostClickTapDelay = options.ghostClickTapDelay || this.tapDelay * 3;
+
 	if (FastClick.notNeeded(layer)) {
 		return;
 	}
@@ -205,6 +248,13 @@ var deviceIsIOSWithBadTarget = deviceIsIOS && (/OS ([6-9]|\d{2})_\d/).test(navig
 var deviceIsBlackBerry10 = navigator.userAgent.indexOf('BB10') > 0;
 
 /**
+ * Android devices or specifically enabled
+ *
+ * @type boolean
+ */
+ var deviceIsGhostClickAfflicted = this.enableGhostClickCheck || deviceIsAndroid;
+
+/**
  * Determine whether a given element requires a native click.
  *
  * @param {EventTarget|Element} target Target DOM element
@@ -294,6 +344,12 @@ FastClick.prototype.sendClick = function(targetElement, event) {
 	clickEvent.initMouseEvent(this.determineEventType(targetElement), true, true, window, 1, touch.screenX, touch.screenY, touch.clientX, touch.clientY, false, false, false, false, 0, null);
 	clickEvent.forwardedTouchEvent = true;
 	targetElement.dispatchEvent(clickEvent);
+
+	// Ghostclick
+	if(deviceIsGhostClickAfflicted) {
+		this.clickedNow();	
+	}
+	
 };
 
 FastClick.prototype.determineEventType = function(targetElement) {
@@ -624,6 +680,28 @@ FastClick.prototype.onTouchCancel = function() {
 FastClick.prototype.onMouse = function(event) {
 	'use strict';
 
+	var stopEvent = function(event) {
+		
+		// Prevent any user-added listeners declared on FastClick element from being fired.
+		if (event.stopImmediatePropagation) {
+			event.stopImmediatePropagation();
+		} else {
+			// Part of the hack for browsers that don't support Event#stopImmediatePropagation (e.g. Android 2)
+			event.propagationStopped = true;
+		}
+
+		// Cancel the event
+		event.stopPropagation();
+		event.preventDefault();
+
+		return false;
+	}
+
+	// Ghost clicks don't present as anything other that a click really soon after the previous click
+	if (deviceIsGhostClickAfflicted && this.isGhostClick()) {
+		return stopEvent(event);
+	}
+
 	// If a target element was never set (because a touch event was never fired) allow the event
 	if (!this.targetElement) {
 		return true;
@@ -642,25 +720,33 @@ FastClick.prototype.onMouse = function(event) {
 	// unless explicitly enabled, prevent non-touch click events from triggering actions,
 	// to prevent ghost/doubleclicks.
 	if (!this.needsClick(this.targetElement) || this.cancelNextClick) {
-
-		// Prevent any user-added listeners declared on FastClick element from being fired.
-		if (event.stopImmediatePropagation) {
-			event.stopImmediatePropagation();
-		} else {
-
-			// Part of the hack for browsers that don't support Event#stopImmediatePropagation (e.g. Android 2)
-			event.propagationStopped = true;
-		}
-
-		// Cancel the event
-		event.stopPropagation();
-		event.preventDefault();
-
-		return false;
+		return stopEvent(event);
 	}
-
+	
 	// If the mouse event is permitted, return true for the action to go through.
 	return true;
+};
+
+/**
+ * Sets the timestamp of the last click
+ *
+ */
+FastClick.prototype.clickedNow = function() {
+	this.setClickedNowTimestamp(new Date().getTime());
+};
+
+/**
+ * Determine whether this might be a ghost click
+ *
+ * @type boolean
+ */ 
+FastClick.prototype.isGhostClick = function() {
+	if(this.getClickedNowTimestamp) {
+		if(new Date().getTime() - this.getClickedNowTimestamp() < this.ghostClickTapDelay) {
+			console.log("isGhostClick:" + (new Date().getTime() - this.getClickedNowTimestamp()) + " and threshold is " + this.ghostClickTapDelay);
+			return true;
+		}
+	}
 };
 
 

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -699,6 +699,7 @@ FastClick.prototype.onMouse = function(event) {
 
 	// Ghost clicks don't present as anything other that a click really soon after the previous click
 	if (deviceIsGhostClickAfflicted && this.isGhostClick()) {
+		console.log("STOP")
 		return stopEvent(event);
 	}
 
@@ -741,9 +742,13 @@ FastClick.prototype.clickedNow = function() {
  * @type boolean
  */ 
 FastClick.prototype.isGhostClick = function() {
+	console.log("yep checking for ghosts")
 	if(this.getClickedNowTimestamp) {
+		console.log("isGhostClick:" + (new Date().getTime() - this.getClickedNowTimestamp()) + " and threshold is " + this.ghostClickTapDelay);
+			
 		if(new Date().getTime() - this.getClickedNowTimestamp() < this.ghostClickTapDelay) {
-			console.log("isGhostClick:" + (new Date().getTime() - this.getClickedNowTimestamp()) + " and threshold is " + this.ghostClickTapDelay);
+			
+			console.log("ITS A GHOST");
 			return true;
 		}
 	}
@@ -775,6 +780,7 @@ FastClick.prototype.onClick = function(event) {
 	}
 
 	permitted = this.onMouse(event);
+	console.log("PERMITTED:" + permitted);
 
 	// Only unset targetElement if the click is not permitted. This will ensure that the check for !targetElement in onMouse fails and the browser's click doesn't go through.
 	if (!permitted) {

--- a/tests/146.html
+++ b/tests/146.html
@@ -7,7 +7,7 @@
 	textarea { width: 25em; height: 15em; }
 	.big { width:100px; height:100px; border-style: solid; }
 </style>
-<title>#6</title>
+<title>#146</title>
 <script type="application/javascript" src="../lib/fastclick.js"></script>
 <script type="application/javascript">
 

--- a/tests/146.html
+++ b/tests/146.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<style type="text/css">
+	p { font-family: sans-serif; }
+	textarea { width: 25em; height: 15em; }
+	.big { width:100px; height:100px; border-style: solid; }
+</style>
+<title>#6</title>
+<script type="application/javascript" src="../lib/fastclick.js"></script>
+<script type="application/javascript">
+	window.addEventListener('load', function() {
+
+		console.log("LOADED")
+
+		document.getElementById("button").addEventListener("click", function() {
+			
+			document.getElementById("button2").style.display="inline-block";
+
+			document.getElementById("button").style.display="none";
+			
+		});
+
+		document.getElementById("button2").addEventListener("click", function() {
+			document.getElementById("button2").innerHTML = "Boo its a ghost";
+		});
+
+		new FastClick(document.getElementById("button"));
+		new FastClick(document.getElementById("button2"));
+	}, false);
+
+	start = function() {
+		
+	}
+</script>
+</head>
+<body>
+	
+	<div id="button" class="big">Ghost click check</div>
+	<div id="button2" class="big" style="display:none;">Ghost bustered!</div>
+	<div class="big" onclick="start()"></div>
+</body>
+</html>

--- a/tests/146.html
+++ b/tests/146.html
@@ -10,35 +10,49 @@
 <title>#6</title>
 <script type="application/javascript" src="../lib/fastclick.js"></script>
 <script type="application/javascript">
+
+	var setStyle = function(e) {
+		e.style.width = "100px";
+		e.style.height = "100px";
+	}
+
+	startDynamicContentCreation = function() {
+		var b1 = document.createElement("button");
+		b1.appendChild(document.createTextNode("Run Ghost check"));
+		setStyle(b1);
+
+		b1.addEventListener("click", function() {
+			
+			var b2 = document.createElement("button");
+			b2.appendChild(document.createTextNode("Ghost Click Busted!"));
+			setStyle(b2);
+			b2.addEventListener("click", function() {
+				b2.innerHTML = "Boo its a ghost";
+			});
+			document.getElementById("buttons").appendChild(b2);
+			FastClick.attach(b2);
+
+			b1.style.display="none";
+
+		});
+
+		document.getElementById("buttons").appendChild(b1);
+		FastClick.attach(b1);
+	}
+
 	window.addEventListener('load', function() {
 
-		console.log("LOADED")
-
-		document.getElementById("button").addEventListener("click", function() {
-			
-			document.getElementById("button2").style.display="inline-block";
-
-			document.getElementById("button").style.display="none";
-			
-		});
-
-		document.getElementById("button2").addEventListener("click", function() {
-			document.getElementById("button2").innerHTML = "Boo its a ghost";
-		});
-
-		new FastClick(document.getElementById("button"));
-		new FastClick(document.getElementById("button2"));
+		console.log("LOADED");
+		FastClick.attach(document.body);
+		startDynamicContentCreation();
+		
 	}, false);
 
-	start = function() {
-		
-	}
+	
 </script>
 </head>
 <body>
-	
-	<div id="button" class="big">Ghost click check</div>
-	<div id="button2" class="big" style="display:none;">Ghost bustered!</div>
-	<div class="big" onclick="start()"></div>
+	<div id="buttons">
+	</div>
 </body>
 </html>


### PR DESCRIPTION
Hi there, this is a patch for several issues that involve ghost clicks on android when content is created with dynamic javascript and bound to a different instance of fastclick.

It uses a configurable function that presents a shared variable to track the last click time, and simply stops any clicks too soon after the previous click.

This only accounts for tap timings, an easy change could be to track the coordinates as well.

I have found that you MUST have a FastClick bound to the document.body for this to be effective. 
