### PR TITLE
Added support for mouseup and mousedown event support

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -289,15 +289,15 @@ FastClick.prototype.sendClick = function(targetElement, event) {
 
 	touch = event.changedTouches[0];
     
-    mouseUpEvent = document.createEvent('MouseEvents');
-	mouseUpEvent.initMouseEvent('mouseup', true, true, window, 1, touch.screenX, touch.screenY, touch.clientX, touch.clientY, false, false, false, false, 0, null);
-	mouseUpEvent.forwardedTouchEvent = true;
-	targetElement.dispatchEvent(mouseUpEvent);
-
-    mouseDownEvent = document.createEvent('MouseEvents');
+	mouseDownEvent = document.createEvent('MouseEvents');
 	mouseDownEvent.initMouseEvent('mousedown', true, true, window, 1, touch.screenX, touch.screenY, touch.clientX, touch.clientY, false, false, false, false, 0, null);
 	mouseDownEvent.forwardedTouchEvent = true;
 	targetElement.dispatchEvent(mouseDownEvent);
+
+	mouseUpEvent = document.createEvent('MouseEvents');
+	mouseUpEvent.initMouseEvent('mouseup', true, true, window, 1, touch.screenX, touch.screenY, touch.clientX, touch.clientY, false, false, false, false, 0, null);
+	mouseUpEvent.forwardedTouchEvent = true;
+	targetElement.dispatchEvent(mouseUpEvent);
 
 	// Synthesise a click event, with an extra attribute so it can be tracked
 	clickEvent = document.createEvent('MouseEvents');


### PR DESCRIPTION
Added support for mouseup and mousedown event support. 
This fixed that some dropdown plugin relies on `mouseup` and `mousedown` event, and it doesn't work in fastclick.
