### PR TITLE
Add timeout to tap

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -99,7 +99,7 @@ function FastClick(layer, options) {
 	 *
 	 * @type number
 	 */
-	this.tapWindow = options.tapTimeout || 700;
+	this.tapTimeout = options.tapTimeout || 700;
 
 	if (FastClick.notNeeded(layer)) {
 		return;


### PR DESCRIPTION
Further to https://github.com/ftlabs/fastclick/issues/292...

Browsers allow you to hold touch down on a link, to bring up a context menu ('Open in New Tab', etc). Even after this window has opened, Android still fires the `touchEnd` event when the user releases. This can cause strange behaviour, for instance selecting 'Open in New Tab' will indeed open the page in a new tab, but the current tab will also load the selected link.

Note, doesn't happen on iPhone

This adds a timeout to a tap; i.e. if a tap takes longer than 700ms (by default), we assume the user is holding their finger down for a reason, and doesn't fire a fastclick. _Seems_ like browsers open the context menu at around the 800ms mark
