### PR TITLE
Tapping on a textarea element in an IFRAME on iOS blocks text entry.  Th...

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -554,7 +554,7 @@
 	
 			// Case 1: If the touch started a while ago (best guess is 100ms based on tests for issue #36) then focus will be triggered anyway. Return early and unset the target element reference so that the subsequent click will be allowed through.
 			// Case 2: Without this exception for input elements tapped when the document is contained in an iframe, then any inputted text won't be visible even though the value attribute is updated as the user types (issue #37).
-			if ((event.timeStamp - trackingClickStart) > 100 || (deviceIsIOS && window.top !== window && targetTagName === 'input')) {
+            if ((event.timeStamp - trackingClickStart) > 100 || (deviceIsIOS && window.top !== window && (targetTagName === 'input' || targetTagName === 'textarea') )) {
 				this.targetElement = null;
 				return false;
 			}

--- a/tests/37a.html
+++ b/tests/37a.html
@@ -12,7 +12,7 @@
 
 </head>
 <body>
-	<p>On touching/clicking the input field within the iframe, you should be able to input text normally.</p>
+	<p>On touching/clicking the input field or textarea within the iframe, you should be able to input text normally.</p>
 	<iframe src="37b.html"></iframe>
 </body>
 </html>

--- a/tests/37b.html
+++ b/tests/37b.html
@@ -23,5 +23,8 @@
 </head>
 <body>
 	<input type="text" id="mytext" name="mytext" />
+    <p>
+	    <textarea id="myTextArea" name="myTextArea"></textarea>
+    </p>
 </body>
 </html>


### PR DESCRIPTION
...is issue was addressed for <input type="text"> elements as part of issue #37, but the problem also exists for text areas.
