### PR TITLE
Clarify Twitter Bootstrap dropdown compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ Internally, FastClick uses `document.createEvent` to fire a synthetic `click` ev
 
 This is where the `needsclick` class comes in. Add the class to any element that requires a non-synthetic click.
 
-#### Use case 2: Twitter Bootstrap 2.2.2 dropdowns ####
+#### Use case 2: Twitter Bootstrap dropdowns (2.1.x and 2.2.x) ####
 
-Another example of when to use the `needsclick` class is with dropdowns in Twitter Bootstrap 2.2.2. Bootstrap add its own `touchstart` listener for dropdowns, so you want to tell FastClick to ignore those. If you don't, touch devices will automatically close the dropdown as soon as it is clicked, because both FastClick and Bootstrap execute the synthetic click, one opens the dropdown, the second closes it immediately after.
+Another example of when to use the `needsclick` class is with dropdowns in Twitter Bootstrap 2.1.x and 2.2.x. Bootstrap add its own `touchstart` listener for dropdowns, so you want to tell FastClick to ignore those. If you don't, touch devices will automatically close the dropdown as soon as it is clicked, because both FastClick and Bootstrap execute the synthetic click, one opens the dropdown, the second closes it immediately after.  This issue was resolved in Twitter Bootstrap 2.3.0 and later releases (including 3.0.0) which no longer register a `touchstart` listener.
 
 ```html
 <a class="dropdown-toggle needsclick" data-toggle="dropdown">Dropdown</a>


### PR DESCRIPTION
Hello FastClick developers,

"Use case 2" in the README describes a compatibility issue with Twitter Bootstrap 2.2.2.  After reading this, I was unsure about whether the issue only applied to version 2.2.2 or whether this workaround was
still required.  After some investigation, it appears that the compatibility issue was introduced in twbs/bootstrap@c9cef741 (included in `v2.1.0` and later) and was resolved in twbs/bootstrap@b5ad5068
(included in `v2.3.0` and later, including `v3.0.0`) as a result of twbs/bootstrap#6488.

To avoid causing confusion for future users who may not know about the state of this issue, this commit clarifies which versions of Twitter Bootstrap are affected.

Thanks for considering,
Kevin
