### PR TITLE
Fixes issues #226 and #268

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -559,13 +559,16 @@
 				return false;
 			}
 	
+			var savedPageYOffset = window.pageYOffset;
 			this.focus(targetElement);
 			this.sendClick(targetElement, event);
 	
 			// Select elements need the event to go through on iOS 4, otherwise the selector menu won't open.
-			// Also this breaks opening selects when VoiceOver is active on iOS6, iOS7 (and possibly others)
-			if (!deviceIsIOS || targetTagName !== 'select') {
+			if (!deviceIsIOS4 || targetTagName !== 'select') {
 				this.targetElement = null;
+				// If the page moved (keyboard opened on iOS), then preventDefault to keep any other input fields from receiving focus.
+				// If the page didn't move, allow the event to take the default action (so that, for example, iOS VoiceOver continues to work).
+				if (window.pageYOffset != savedPageYOffset)
 				event.preventDefault();
 			}
 	


### PR DESCRIPTION
Checks if the focus & click events cause the screen to move,
and if so (non-VoiceOver case), doesn't a preventDefault; if not (VoiceOver
case), doesn't do the preventDefault.
