### PR TITLE
iOS8 homescreen app iframe fix

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -1,6 +1,6 @@
 (function () {
 	'use strict';
-	
+
 	/**
 	 * @preserve FastClick: polyfill to remove click delays on browsers with touch UIs.
 	 *
@@ -9,11 +9,11 @@
 	 * @copyright The Financial Times Limited [All Rights Reserved]
 	 * @license MIT License (see LICENSE.txt)
 	 */
-	
+
 	/*jslint browser:true, node:true*/
 	/*global define, Event, Node*/
-	
-	
+
+
 	/**
 	 * Instantiate fast-clicking listeners on the specified layer.
 	 *
@@ -23,108 +23,108 @@
 	 */
 	function FastClick(layer, options) {
 		var oldOnClick;
-	
+
 		options = options || {};
-	
+
 		/**
 		 * Whether a click is currently being tracked.
 		 *
 		 * @type boolean
 		 */
 		this.trackingClick = false;
-	
-	
+
+
 		/**
 		 * Timestamp for when click tracking started.
 		 *
 		 * @type number
 		 */
 		this.trackingClickStart = 0;
-	
-	
+
+
 		/**
 		 * The element being tracked for a click.
 		 *
 		 * @type EventTarget
 		 */
 		this.targetElement = null;
-	
-	
+
+
 		/**
 		 * X-coordinate of touch start event.
 		 *
 		 * @type number
 		 */
 		this.touchStartX = 0;
-	
-	
+
+
 		/**
 		 * Y-coordinate of touch start event.
 		 *
 		 * @type number
 		 */
 		this.touchStartY = 0;
-	
-	
+
+
 		/**
 		 * ID of the last touch, retrieved from Touch.identifier.
 		 *
 		 * @type number
 		 */
 		this.lastTouchIdentifier = 0;
-	
-	
+
+
 		/**
 		 * Touchmove boundary, beyond which a click will be cancelled.
 		 *
 		 * @type number
 		 */
 		this.touchBoundary = options.touchBoundary || 10;
-	
-	
+
+
 		/**
 		 * The FastClick layer.
 		 *
 		 * @type Element
 		 */
 		this.layer = layer;
-	
+
 		/**
 		 * The minimum time between tap(touchstart and touchend) events
 		 *
 		 * @type number
 		 */
 		this.tapDelay = options.tapDelay || 200;
-	
+
 		if (FastClick.notNeeded(layer)) {
 			return;
 		}
-	
+
 		// Some old versions of Android don't have Function.prototype.bind
 		function bind(method, context) {
 			return function() { return method.apply(context, arguments); };
 		}
-	
-	
+
+
 		var methods = ['onMouse', 'onClick', 'onTouchStart', 'onTouchMove', 'onTouchEnd', 'onTouchCancel'];
 		var context = this;
 		for (var i = 0, l = methods.length; i < l; i++) {
 			context[methods[i]] = bind(context[methods[i]], context);
 		}
-	
+
 		// Set up event handlers as required
 		if (deviceIsAndroid) {
 			layer.addEventListener('mouseover', this.onMouse, true);
 			layer.addEventListener('mousedown', this.onMouse, true);
 			layer.addEventListener('mouseup', this.onMouse, true);
 		}
-	
+
 		layer.addEventListener('click', this.onClick, true);
 		layer.addEventListener('touchstart', this.onTouchStart, false);
 		layer.addEventListener('touchmove', this.onTouchMove, false);
 		layer.addEventListener('touchend', this.onTouchEnd, false);
 		layer.addEventListener('touchcancel', this.onTouchCancel, false);
-	
+
 		// Hack is required for browsers that don't support Event#stopImmediatePropagation (e.g. Android 2)
 		// which is how FastClick normally stops click events bubbling to callbacks registered on the FastClick
 		// layer when they are cancelled.
@@ -137,7 +137,7 @@
 					rmv.call(layer, type, callback, capture);
 				}
 			};
-	
+
 			layer.addEventListener = function(type, callback, capture) {
 				var adv = Node.prototype.addEventListener;
 				if (type === 'click') {
@@ -151,12 +151,12 @@
 				}
 			};
 		}
-	
+
 		// If a handler is already declared in the element's onclick attribute, it will be fired before
 		// FastClick's onClick handler. Fix this by pulling out the user-defined handler function and
 		// adding it as listener.
 		if (typeof layer.onclick === 'function') {
-	
+
 			// Android browser on at least 3.2 requires a new reference to the function in layer.onclick
 			// - the old one won't work if passed to addEventListener directly.
 			oldOnClick = layer.onclick;
@@ -166,46 +166,46 @@
 			layer.onclick = null;
 		}
 	}
-	
-	
+
+
 	/**
 	 * Android requires exceptions.
 	 *
 	 * @type boolean
 	 */
 	var deviceIsAndroid = navigator.userAgent.indexOf('Android') > 0;
-	
-	
+
+
 	/**
 	 * iOS requires exceptions.
 	 *
 	 * @type boolean
 	 */
 	var deviceIsIOS = /iP(ad|hone|od)/.test(navigator.userAgent);
-	
-	
+
+
 	/**
 	 * iOS 4 requires an exception for select elements.
 	 *
 	 * @type boolean
 	 */
 	var deviceIsIOS4 = deviceIsIOS && (/OS 4_\d(_\d)?/).test(navigator.userAgent);
-	
-	
+
+
 	/**
 	 * iOS 6.0(+?) requires the target element to be manually derived
 	 *
 	 * @type boolean
 	 */
 	var deviceIsIOSWithBadTarget = deviceIsIOS && (/OS ([6-9]|\d{2})_\d/).test(navigator.userAgent);
-	
+
 	/**
 	 * BlackBerry requires exceptions.
 	 *
 	 * @type boolean
 	 */
 	var deviceIsBlackBerry10 = navigator.userAgent.indexOf('BB10') > 0;
-	
+
 	/**
 	 * Determine whether a given element requires a native click.
 	 *
@@ -214,7 +214,7 @@
 	 */
 	FastClick.prototype.needsClick = function(target) {
 		switch (target.nodeName.toLowerCase()) {
-	
+
 		// Don't send a synthetic click to disabled inputs (issue #62)
 		case 'button':
 		case 'select':
@@ -222,25 +222,26 @@
 			if (target.disabled) {
 				return true;
 			}
-	
+
 			break;
 		case 'input':
-	
+
 			// File inputs need real clicks on iOS 6 due to a browser bug (issue #68)
 			if ((deviceIsIOS && target.type === 'file') || target.disabled) {
 				return true;
 			}
-	
+
 			break;
 		case 'label':
+		case 'iframe': // iOS8 homescreen apps can prevent events bubbling into frames
 		case 'video':
 			return true;
 		}
-	
+
 		return (/\bneedsclick\b/).test(target.className);
 	};
-	
-	
+
+
 	/**
 	 * Determine whether a given element requires a call to focus to simulate click into element.
 	 *
@@ -263,15 +264,15 @@
 			case 'submit':
 				return false;
 			}
-	
+
 			// No point in attempting to focus disabled inputs
 			return !target.disabled && !target.readOnly;
 		default:
 			return (/\bneedsfocus\b/).test(target.className);
 		}
 	};
-	
-	
+
+
 	/**
 	 * Send a click event to the specified element.
 	 *
@@ -280,38 +281,38 @@
 	 */
 	FastClick.prototype.sendClick = function(targetElement, event) {
 		var clickEvent, touch;
-	
+
 		// On some Android devices activeElement needs to be blurred otherwise the synthetic click will have no effect (#24)
 		if (document.activeElement && document.activeElement !== targetElement) {
 			document.activeElement.blur();
 		}
-	
+
 		touch = event.changedTouches[0];
-	
+
 		// Synthesise a click event, with an extra attribute so it can be tracked
 		clickEvent = document.createEvent('MouseEvents');
 		clickEvent.initMouseEvent(this.determineEventType(targetElement), true, true, window, 1, touch.screenX, touch.screenY, touch.clientX, touch.clientY, false, false, false, false, 0, null);
 		clickEvent.forwardedTouchEvent = true;
 		targetElement.dispatchEvent(clickEvent);
 	};
-	
+
 	FastClick.prototype.determineEventType = function(targetElement) {
-	
+
 		//Issue #159: Android Chrome Select Box does not open with a synthetic click event
 		if (deviceIsAndroid && targetElement.tagName.toLowerCase() === 'select') {
 			return 'mousedown';
 		}
-	
+
 		return 'click';
 	};
-	
-	
+
+
 	/**
 	 * @param {EventTarget|Element} targetElement
 	 */
 	FastClick.prototype.focus = function(targetElement) {
 		var length;
-	
+
 		// Issue #160: on iOS 7, some input elements (e.g. date datetime month) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
 		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month') {
 			length = targetElement.value.length;
@@ -320,8 +321,8 @@
 			targetElement.focus();
 		}
 	};
-	
-	
+
+
 	/**
 	 * Check whether the given target element is a child of a scrollable layer and if so, set a flag on it.
 	 *
@@ -329,9 +330,9 @@
 	 */
 	FastClick.prototype.updateScrollParent = function(targetElement) {
 		var scrollParent, parentElement;
-	
+
 		scrollParent = targetElement.fastClickScrollParent;
-	
+
 		// Attempt to discover whether the target element is contained within a scrollable layer. Re-check if the
 		// target element was moved to another parent.
 		if (!scrollParent || !scrollParent.contains(targetElement)) {
@@ -342,33 +343,33 @@
 					targetElement.fastClickScrollParent = parentElement;
 					break;
 				}
-	
+
 				parentElement = parentElement.parentElement;
 			} while (parentElement);
 		}
-	
+
 		// Always update the scroll top tracker if possible.
 		if (scrollParent) {
 			scrollParent.fastClickLastScrollTop = scrollParent.scrollTop;
 		}
 	};
-	
-	
+
+
 	/**
 	 * @param {EventTarget} targetElement
 	 * @returns {Element|EventTarget}
 	 */
 	FastClick.prototype.getTargetElementFromEventTarget = function(eventTarget) {
-	
+
 		// On some older browsers (notably Safari on iOS 4.1 - see issue #56) the event target may be a text node.
 		if (eventTarget.nodeType === Node.TEXT_NODE) {
 			return eventTarget.parentNode;
 		}
-	
+
 		return eventTarget;
 	};
-	
-	
+
+
 	/**
 	 * On touch start, record the position and scroll offset.
 	 *
@@ -377,25 +378,25 @@
 	 */
 	FastClick.prototype.onTouchStart = function(event) {
 		var targetElement, touch, selection;
-	
+
 		// Ignore multiple touches, otherwise pinch-to-zoom is prevented if both fingers are on the FastClick element (issue #111).
 		if (event.targetTouches.length > 1) {
 			return true;
 		}
-	
+
 		targetElement = this.getTargetElementFromEventTarget(event.target);
 		touch = event.targetTouches[0];
-	
+
 		if (deviceIsIOS) {
-	
+
 			// Only trusted events will deselect text on iOS (issue #49)
 			selection = window.getSelection();
 			if (selection.rangeCount && !selection.isCollapsed) {
 				return true;
 			}
-	
+
 			if (!deviceIsIOS4) {
-	
+
 				// Weird things happen on iOS when an alert or confirm dialog is opened from a click event callback (issue #23):
 				// when the user next taps anywhere else on the page, new touchstart and touchend events are dispatched
 				// with the same identifier as the touch event that previously triggered the click that triggered the alert.
@@ -408,9 +409,9 @@
 					event.preventDefault();
 					return false;
 				}
-	
+
 				this.lastTouchIdentifier = touch.identifier;
-	
+
 				// If the target element is a child of a scrollable layer (using -webkit-overflow-scrolling: touch) and:
 				// 1) the user does a fling scroll on the scrollable layer
 				// 2) the user stops the fling scroll with another tap
@@ -420,23 +421,23 @@
 				this.updateScrollParent(targetElement);
 			}
 		}
-	
+
 		this.trackingClick = true;
 		this.trackingClickStart = event.timeStamp;
 		this.targetElement = targetElement;
-	
+
 		this.touchStartX = touch.pageX;
 		this.touchStartY = touch.pageY;
-	
+
 		// Prevent phantom clicks on fast double-tap (issue #36)
 		if ((event.timeStamp - this.lastClickTime) < this.tapDelay) {
 			event.preventDefault();
 		}
-	
+
 		return true;
 	};
-	
-	
+
+
 	/**
 	 * Based on a touchmove event object, check whether the touch has moved past a boundary since it started.
 	 *
@@ -445,15 +446,15 @@
 	 */
 	FastClick.prototype.touchHasMoved = function(event) {
 		var touch = event.changedTouches[0], boundary = this.touchBoundary;
-	
+
 		if (Math.abs(touch.pageX - this.touchStartX) > boundary || Math.abs(touch.pageY - this.touchStartY) > boundary) {
 			return true;
 		}
-	
+
 		return false;
 	};
-	
-	
+
+
 	/**
 	 * Update the last position.
 	 *
@@ -464,17 +465,17 @@
 		if (!this.trackingClick) {
 			return true;
 		}
-	
+
 		// If the touch has moved, cancel the click tracking
 		if (this.targetElement !== this.getTargetElementFromEventTarget(event.target) || this.touchHasMoved(event)) {
 			this.trackingClick = false;
 			this.targetElement = null;
 		}
-	
+
 		return true;
 	};
-	
-	
+
+
 	/**
 	 * Attempt to find the labelled control for the given label element.
 	 *
@@ -482,23 +483,23 @@
 	 * @returns {Element|null}
 	 */
 	FastClick.prototype.findControl = function(labelElement) {
-	
+
 		// Fast path for newer browsers supporting the HTML5 control attribute
 		if (labelElement.control !== undefined) {
 			return labelElement.control;
 		}
-	
+
 		// All browsers under test that support touch events also support the HTML5 htmlFor attribute
 		if (labelElement.htmlFor) {
 			return document.getElementById(labelElement.htmlFor);
 		}
-	
+
 		// If no for attribute exists, attempt to retrieve the first labellable descendant element
 		// the list of which is defined here: http://www.w3.org/TR/html5/forms.html#category-label
 		return labelElement.querySelector('button, input:not([type=hidden]), keygen, meter, output, progress, select, textarea');
 	};
-	
-	
+
+
 	/**
 	 * On touch end, determine whether to send a click event at once.
 	 *
@@ -507,38 +508,38 @@
 	 */
 	FastClick.prototype.onTouchEnd = function(event) {
 		var forElement, trackingClickStart, targetTagName, scrollParent, touch, targetElement = this.targetElement;
-	
+
 		if (!this.trackingClick) {
 			return true;
 		}
-	
+
 		// Prevent phantom clicks on fast double-tap (issue #36)
 		if ((event.timeStamp - this.lastClickTime) < this.tapDelay) {
 			this.cancelNextClick = true;
 			return true;
 		}
-	
+
 		// Reset to prevent wrong click cancel on input (issue #156).
 		this.cancelNextClick = false;
-	
+
 		this.lastClickTime = event.timeStamp;
-	
+
 		trackingClickStart = this.trackingClickStart;
 		this.trackingClick = false;
 		this.trackingClickStart = 0;
-	
+
 		// On some iOS devices, the targetElement supplied with the event is invalid if the layer
 		// is performing a transition or scroll, and has to be re-detected manually. Note that
 		// for this to function correctly, it must be called *after* the event target is checked!
 		// See issue #57; also filed as rdar://13048589 .
 		if (deviceIsIOSWithBadTarget) {
 			touch = event.changedTouches[0];
-	
+
 			// In certain cases arguments of elementFromPoint can be negative, so prevent setting targetElement to null
 			targetElement = document.elementFromPoint(touch.pageX - window.pageXOffset, touch.pageY - window.pageYOffset) || targetElement;
 			targetElement.fastClickScrollParent = this.targetElement.fastClickScrollParent;
 		}
-	
+
 		targetTagName = targetElement.tagName.toLowerCase();
 		if (targetTagName === 'label') {
 			forElement = this.findControl(targetElement);
@@ -547,33 +548,33 @@
 				if (deviceIsAndroid) {
 					return false;
 				}
-	
+
 				targetElement = forElement;
 			}
 		} else if (this.needsFocus(targetElement)) {
-	
+
 			// Case 1: If the touch started a while ago (best guess is 100ms based on tests for issue #36) then focus will be triggered anyway. Return early and unset the target element reference so that the subsequent click will be allowed through.
 			// Case 2: Without this exception for input elements tapped when the document is contained in an iframe, then any inputted text won't be visible even though the value attribute is updated as the user types (issue #37).
 			if ((event.timeStamp - trackingClickStart) > 100 || (deviceIsIOS && window.top !== window && targetTagName === 'input')) {
 				this.targetElement = null;
 				return false;
 			}
-	
+
 			this.focus(targetElement);
 			this.sendClick(targetElement, event);
-	
+
 			// Select elements need the event to go through on iOS 4, otherwise the selector menu won't open.
 			// Also this breaks opening selects when VoiceOver is active on iOS6, iOS7 (and possibly others)
 			if (!deviceIsIOS || targetTagName !== 'select') {
 				this.targetElement = null;
 				event.preventDefault();
 			}
-	
+
 			return false;
 		}
-	
+
 		if (deviceIsIOS && !deviceIsIOS4) {
-	
+
 			// Don't send a synthetic click event if the target element is contained within a parent layer that was scrolled
 			// and this tap is being used to stop the scrolling (usually initiated by a fling - issue #42).
 			scrollParent = targetElement.fastClickScrollParent;
@@ -581,18 +582,18 @@
 				return true;
 			}
 		}
-	
+
 		// Prevent the actual click from going though - unless the target node is marked as requiring
 		// real clicks or if it is in the whitelist in which case only non-programmatic clicks are permitted.
 		if (!this.needsClick(targetElement)) {
 			event.preventDefault();
 			this.sendClick(targetElement, event);
 		}
-	
+
 		return false;
 	};
-	
-	
+
+
 	/**
 	 * On touch cancel, stop tracking the click.
 	 *
@@ -602,8 +603,8 @@
 		this.trackingClick = false;
 		this.targetElement = null;
 	};
-	
-	
+
+
 	/**
 	 * Determine mouse events which should be permitted.
 	 *
@@ -611,47 +612,47 @@
 	 * @returns {boolean}
 	 */
 	FastClick.prototype.onMouse = function(event) {
-	
+
 		// If a target element was never set (because a touch event was never fired) allow the event
 		if (!this.targetElement) {
 			return true;
 		}
-	
+
 		if (event.forwardedTouchEvent) {
 			return true;
 		}
-	
+
 		// Programmatically generated events targeting a specific element should be permitted
 		if (!event.cancelable) {
 			return true;
 		}
-	
+
 		// Derive and check the target element to see whether the mouse event needs to be permitted;
 		// unless explicitly enabled, prevent non-touch click events from triggering actions,
 		// to prevent ghost/doubleclicks.
 		if (!this.needsClick(this.targetElement) || this.cancelNextClick) {
-	
+
 			// Prevent any user-added listeners declared on FastClick element from being fired.
 			if (event.stopImmediatePropagation) {
 				event.stopImmediatePropagation();
 			} else {
-	
+
 				// Part of the hack for browsers that don't support Event#stopImmediatePropagation (e.g. Android 2)
 				event.propagationStopped = true;
 			}
-	
+
 			// Cancel the event
 			event.stopPropagation();
 			event.preventDefault();
-	
+
 			return false;
 		}
-	
+
 		// If the mouse event is permitted, return true for the action to go through.
 		return true;
 	};
-	
-	
+
+
 	/**
 	 * On actual clicks, determine whether this is a touch-generated click, a click action occurring
 	 * naturally after a delay after a touch (which needs to be cancelled to avoid duplication), or
@@ -662,31 +663,31 @@
 	 */
 	FastClick.prototype.onClick = function(event) {
 		var permitted;
-	
+
 		// It's possible for another FastClick-like library delivered with third-party code to fire a click event before FastClick does (issue #44). In that case, set the click-tracking flag back to false and return early. This will cause onTouchEnd to return early.
 		if (this.trackingClick) {
 			this.targetElement = null;
 			this.trackingClick = false;
 			return true;
 		}
-	
+
 		// Very odd behaviour on iOS (issue #18): if a submit element is present inside a form and the user hits enter in the iOS simulator or clicks the Go button on the pop-up OS keyboard the a kind of 'fake' click event will be triggered with the submit-type input element as the target.
 		if (event.target.type === 'submit' && event.detail === 0) {
 			return true;
 		}
-	
+
 		permitted = this.onMouse(event);
-	
+
 		// Only unset targetElement if the click is not permitted. This will ensure that the check for !targetElement in onMouse fails and the browser's click doesn't go through.
 		if (!permitted) {
 			this.targetElement = null;
 		}
-	
+
 		// If clicks are permitted, return true for the action to go through.
 		return permitted;
 	};
-	
-	
+
+
 	/**
 	 * Remove all FastClick's event listeners.
 	 *
@@ -694,21 +695,21 @@
 	 */
 	FastClick.prototype.destroy = function() {
 		var layer = this.layer;
-	
+
 		if (deviceIsAndroid) {
 			layer.removeEventListener('mouseover', this.onMouse, true);
 			layer.removeEventListener('mousedown', this.onMouse, true);
 			layer.removeEventListener('mouseup', this.onMouse, true);
 		}
-	
+
 		layer.removeEventListener('click', this.onClick, true);
 		layer.removeEventListener('touchstart', this.onTouchStart, false);
 		layer.removeEventListener('touchmove', this.onTouchMove, false);
 		layer.removeEventListener('touchend', this.onTouchEnd, false);
 		layer.removeEventListener('touchcancel', this.onTouchCancel, false);
 	};
-	
-	
+
+
 	/**
 	 * Check whether FastClick is needed.
 	 *
@@ -718,20 +719,20 @@
 		var metaViewport;
 		var chromeVersion;
 		var blackberryVersion;
-	
+
 		// Devices that don't support touch don't need FastClick
 		if (typeof window.ontouchstart === 'undefined') {
 			return true;
 		}
-	
+
 		// Chrome version - zero for other browsers
 		chromeVersion = +(/Chrome\/([0-9]+)/.exec(navigator.userAgent) || [,0])[1];
-	
+
 		if (chromeVersion) {
-	
+
 			if (deviceIsAndroid) {
 				metaViewport = document.querySelector('meta[name=viewport]');
-	
+
 				if (metaViewport) {
 					// Chrome on Android with user-scalable="no" doesn't need FastClick (issue #89)
 					if (metaViewport.content.indexOf('user-scalable=no') !== -1) {
@@ -742,21 +743,21 @@
 						return true;
 					}
 				}
-	
+
 			// Chrome desktop doesn't need FastClick (issue #15)
 			} else {
 				return true;
 			}
 		}
-	
+
 		if (deviceIsBlackBerry10) {
 			blackberryVersion = navigator.userAgent.match(/Version\/([0-9]*)\.([0-9]*)/);
-	
+
 			// BlackBerry 10.3+ does not require Fastclick library.
 			// https://github.com/ftlabs/fastclick/issues/251
 			if (blackberryVersion[1] >= 10 && blackberryVersion[2] >= 3) {
 				metaViewport = document.querySelector('meta[name=viewport]');
-	
+
 				if (metaViewport) {
 					// user-scalable=no eliminates click delay.
 					if (metaViewport.content.indexOf('user-scalable=no') !== -1) {
@@ -769,16 +770,16 @@
 				}
 			}
 		}
-	
+
 		// IE10 with -ms-touch-action: none, which disables double-tap-to-zoom (issue #97)
 		if (layer.style.msTouchAction === 'none') {
 			return true;
 		}
-	
+
 		return false;
 	};
-	
-	
+
+
 	/**
 	 * Factory method for creating a FastClick object
 	 *
@@ -788,10 +789,10 @@
 	FastClick.attach = function(layer, options) {
 		return new FastClick(layer, options);
 	};
-	
-	
+
+
 	if (typeof define == 'function' && typeof define.amd == 'object' && define.amd) {
-	
+
 		// AMD. Register as an anonymous module.
 		define(function() {
 			return FastClick;


### PR DESCRIPTION
In iOS 8.0.2:
- if you add app to homescreen
- attach FastClick in the (parent) document
- add `iframe` and listen to events in the iframe

The framed document won't "see" any events.
