### PR TITLE
jsdoc fix

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -784,7 +784,7 @@
 	 * Factory method for creating a FastClick object
 	 *
 	 * @param {Element} layer The layer to listen on
-	 * @param {Object} [options] The options to override the defaults
+	 * @param {Object} [options={}] The options to override the defaults
 	 */
 	FastClick.attach = function(layer, options) {
 		return new FastClick(layer, options);


### PR DESCRIPTION
Correct JSDoc for the public methods, by marking the `options` argument as optional. This solves some IDE (WebStorm in my case) issues where the function call is marked as incomplete.
