### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,14 @@ The script must be loaded prior to instantiating FastClick on any element of the
 To instantiate FastClick on the `body`, which is the recommended method of use:
 
 ```js
-document.addEventListener('DOMContentLoaded', function() {
-	FastClick.attach(document.body);
-}, false);
+if ('addEventListener' in document) {
+	document.addEventListener('DOMContentLoaded', function() {
+		FastClick.attach(document.body);
+	}, false);
+}
 ```
 
-Otherwise, if you're using jQuery:
+Or, if you're using jQuery:
 
 ```js
 $(function() {


### PR DESCRIPTION
- advise using `DOMContentLoaded`, not `load` (#327)
- remove note about using a shim if you want to support IE8 and below. (It's really confusing and well out of scope of this readme.)
