### PR TITLE
#304: Fixed device detection code: Windows Phone 8.1 was detected as And...

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -166,13 +166,19 @@
 		}
 	}
 
+	/**
+	* Windows Phone 8.1 fakes user agent string to look like Android and iPhone.
+	*
+	* @type boolean
+	*/
+	var deviceIsWindowsPhone = navigator.userAgent.indexOf("Windows Phone") >= 0;
 
 	/**
 	 * Android requires exceptions.
 	 *
 	 * @type boolean
 	 */
-	var deviceIsAndroid = navigator.userAgent.indexOf('Android') > 0;
+	var deviceIsAndroid = navigator.userAgent.indexOf('Android') > 0 && !deviceIsWindowsPhone;
 
 
 	/**
@@ -180,7 +186,7 @@
 	 *
 	 * @type boolean
 	 */
-	var deviceIsIOS = /iP(ad|hone|od)/.test(navigator.userAgent);
+	var deviceIsIOS = /iP(ad|hone|od)/.test(navigator.userAgent) && !deviceIsWindowsPhone;
 
 
 	/**


### PR DESCRIPTION
Windows Phone 8.1 [fakes user agent string to be detected as Android or iPhone](http://www.neowin.net/news/ie11-fakes-user-agent-to-fool-gmail-in-windows-phone-81-gdr1-update). This fixes some problems with mobiles sites, but introduce some other problems. Currently `fastclick` incorrectly detects Windows Phone 8.1 device and breaks user interaction with site. This pull request should fix the problem and `fastclick` should work on Windows Phone 8.1 just as good as on Windows Phone 8.0.
