### PR TITLE
#97: Prefixed version of touch-action is no longer supported in IE11+, a...

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -781,6 +781,12 @@
 			return true;
 		}
 
+		// IE11: prefixed -ms-touch-action is no longer supported and it's recomended to use non-prefixed version
+		// http://msdn.microsoft.com/en-us/library/windows/apps/Hh767313.aspx
+		if (layer.style.touchAction === 'none') {
+			return true;
+		}
+
 		return false;
 	};
 


### PR DESCRIPTION
Just [discovered](http://msdn.microsoft.com/en-us/library/windows/apps/Hh767313.aspx) that Microsoft claims that `-ms-touch-action` is no longer supported in `IE11`. And according to [MSDN](http://msdn.microsoft.com/en-us/library/windows/apps/Hh767313.aspx) it's recommended to use non-prefixed `touch-action`.
