### PR TITLE
Ignore onTouchStart if the element needs click

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -399,6 +399,11 @@
 		targetElement = this.getTargetElementFromEventTarget(event.target);
 		touch = event.targetTouches[0];
 
+    // Ignore if the element needs click
+    if (this.needsClick(targetElement)) {
+      return true;
+    }
+
 		if (deviceIsIOS) {
 
 			// Only trusted events will deselect text on iOS (issue #49)


### PR DESCRIPTION
fastclick can ignore elements having `needsclick` class.
I found it doesn't work for events on input[type="text"] elements because the fastclick doesn't ignore `onTouchStart` events.
