### PR TITLE
Added stopPropagation() to handle the case where both touchend AND click listeners have been defined

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -603,6 +603,7 @@
 		// real clicks or if it is in the whitelist in which case only non-programmatic clicks are permitted.
 		if (!this.needsClick(targetElement)) {
 			event.preventDefault();
+                        event.stopPropagation();
 			this.sendClick(targetElement, event);
 		}
 


### PR DESCRIPTION
Added stopPropagation() when the touchEnd event is proxied to a click; without this, having a listener for both touchend and click still fires the touchend listener, causing duplicate events
