### PR TITLE
fix InvalidStateError when focusing an HTML5 input element

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -323,10 +323,11 @@
 	 * @param {EventTarget|Element} targetElement
 	 */
 	FastClick.prototype.focus = function(targetElement) {
-		var length;
+		var length,
+          html5types = ['password', 'email', 'url', 'tel', 'number', 'range', 'time', 'month'];
 
 		// Issue #160: on iOS 7, some input elements (e.g. date datetime month) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
-		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month') {
+		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && html5types.indexOf(targetElement.type) == -1) {
 			length = targetElement.value.length;
 			targetElement.setSelectionRange(length, length);
 		} else {


### PR DESCRIPTION
Fixed error `Uncaught InvalidStateError: Failed to execute 'setSelectionRange' on 'HTMLInputElement': The input element's type ('email') does not support selection.` when focusing an HTML5 input element.
(Solution from [https://github.com/vitalets/x-editable/pull/592](https://github.com/vitalets/x-editable/pull/592))
