### PR TITLE
Remove iOS8 and later from fix #57.

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -205,7 +205,7 @@
 
 
 	/**
-	 * iOS 6.0(+?) requires the target element to be manually derived
+	 * iOS 6.0-7.* requires the target element to be manually derived
 	 *
 	 * @type boolean
 	 */

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -209,7 +209,7 @@
 	 *
 	 * @type boolean
 	 */
-	var deviceIsIOSWithBadTarget = deviceIsIOS && (/OS ([6-9]|\d{2})_\d/).test(navigator.userAgent);
+	var deviceIsIOSWithBadTarget = deviceIsIOS && (/OS ([6-7]|\d{2})_\d/).test(navigator.userAgent);
 
 	/**
 	 * BlackBerry requires exceptions.

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -209,7 +209,7 @@
 	 *
 	 * @type boolean
 	 */
-	var deviceIsIOSWithBadTarget = deviceIsIOS && (/OS ([6-7]|\d{2})_\d/).test(navigator.userAgent);
+	var deviceIsIOSWithBadTarget = deviceIsIOS && (/OS [6-7]_\d/).test(navigator.userAgent);
 
 	/**
 	 * BlackBerry requires exceptions.


### PR DESCRIPTION
Hi everyone!

The buggy behavior of iOS6 and iOS7, which was fixed in #57, is not actual on iOS8. Please lets remove iOS8 from the fix cause it's not needed there. @rowanbeentje can you please share info about rdar://13048589 ?

Thank you.

@njam FYI.