### PR TITLE
A potential solution to issues with Google Places Autocomplete

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -102,6 +102,13 @@
 		 */
 		this.tapTimeout = options.tapTimeout || 700;
 
+                /**
+                 * A node to exclude based on className. Alternative to manually applying needsclick.
+                 *
+                 * @type string
+                 */
+                this.excludeNode = options.excludeNode || null;
+
 		if (FastClick.notNeeded(layer)) {
 			return;
 		}
@@ -250,7 +257,7 @@
 			return true;
 		}
 
-		return (/\bneedsclick\b/).test(target.className);
+		return (/\bneedsclick\b/).test(target.className) || (new RegExp(this.excludeNode).test(target.className)));
 	};
 
 

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -257,7 +257,7 @@
 			return true;
 		}
 
-		return (/\bneedsclick\b/).test(target.className) || (new RegExp(this.excludeNode).test(target.className)));
+		return ((/\bneedsclick\b/).test(target.className) || (new RegExp(this.excludeNode).test(target.className)));
 	};
 
 


### PR DESCRIPTION
This is based on a stack overflow solution to a known issue (#316) where FastClick conflicts with .pac-container in the google places autocomplete dropdown. I've checked out SelectiveFastClick but wasn't too interested in the extra dependencies.

http://stackoverflow.com/a/17176350/3413476

The option to exclude a certain node through tweaking the needsClick method introduces a way for users to use the power of needsclick in config without the need for any other library. In the future maybe an array of classes to ignore would be great, but for now the fix for Autocomplete works when you exclude pac-item only.
