### PR TITLE
Avoid unnecessary breakage due to blur before click

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -295,7 +295,8 @@
 		var clickEvent, touch;
 
 		// On some Android devices activeElement needs to be blurred otherwise the synthetic click will have no effect (#24)
-		if (document.activeElement && document.activeElement !== targetElement) {
+                // Limit to Android devices to avoid unnecessary breakage in code expecting blur after click (#350)
+		if (deviceIsAndroid && document.activeElement && document.activeElement !== targetElement) {
 			document.activeElement.blur();
 		}
 


### PR DESCRIPTION
Hello FastClick developers,

While investigating the incompatibility between FastClick and recent versions of typeahead.js discussed in twitter/typeahead.js#792, I found that the source of the issue is FastClick's call to `blur()` before dispatching the synthetic click event which causes the `blur` event to fire before `click`.  This event order is not expected/supported by typeahead.js.  Although arguably this should be fixed by typeahead.js (too), since the event ordering is unnatural it seems likely that it will trip up other third-party code and therefore should be addressed in FastClick.

This PR doesn't completely fix the problem, but it limits the impact of the issue by only calling `blur()` on Android devices where it is required for proper focus behavior (as described in #24).  It could be further reduced to only the affected Android versions, but I don't currently have a suitable testing environment to determine which versions are affected.

Thanks for considering,
Kevin
