### PR TITLE
walk up to the label before finding target, fixes #351

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -511,6 +511,20 @@
 		return labelElement.querySelector('button, input:not([type=hidden]), keygen, meter, output, progress, select, textarea');
 	};
 
+	/**
+	 * Finds if any of the element's ancestors is a label
+	 *
+	 * @param {EventTarget|HTMLLabelElement} targetElement
+	 * @returns {Element|null}
+	 */
+	FastClick.prototype.closestLabel = function(targetElement) {
+		var el = targetElement;
+		do {
+			if (el.tagName && el.tagName.toLowerCase() === 'label') {
+				return el;
+			}
+		} while((el = el.parentNode));
+	};
 
 	/**
 	 * On touch end, determine whether to send a click event at once.
@@ -519,7 +533,7 @@
 	 * @returns {boolean}
 	 */
 	FastClick.prototype.onTouchEnd = function(event) {
-		var forElement, trackingClickStart, targetTagName, scrollParent, touch, targetElement = this.targetElement;
+		var forElement, trackingClickStart, scrollParent, touch, targetElement = this.targetElement, labelParent;
 
 		if (!this.trackingClick) {
 			return true;
@@ -556,8 +570,9 @@
 			targetElement.fastClickScrollParent = this.targetElement.fastClickScrollParent;
 		}
 
-		targetTagName = targetElement.tagName.toLowerCase();
-		if (targetTagName === 'label') {
+		labelParent = this.closestLabel(targetElement);
+		if (labelParent) {
+			targetElement = labelParent;
 			forElement = this.findControl(targetElement);
 			if (forElement) {
 				this.focus(targetElement);


### PR DESCRIPTION
Fixes #351 by walking up the DOM to check whether we're in a label instead of just checking the `targetElement`. This seems to have minimal performance impact.
