### PR TITLE
Fix errors when certain input fields are focused on iOS

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -325,10 +325,15 @@
 	FastClick.prototype.focus = function(targetElement) {
 		var length;
 
-		// Issue #160: on iOS 7, some input elements (e.g. date datetime month) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
-		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month') {
+
+		if (deviceIsIOS && targetElement.setSelectionRange) {
 			length = targetElement.value.length;
-			targetElement.setSelectionRange(length, length);
+			try {
+				// Issue #160: on iOS 7, some input elements (e.g. date datetime month) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Filed as Apple bug #15122724.
+				targetElement.setSelectionRange(length, length);
+			} catch (err) {
+				targetElement.focus();
+			}
 		} else {
 			targetElement.focus();
 		}


### PR DESCRIPTION
I've received these errors as described in #160 with an `email` input-field as well:

```
"Error: Failed to execute 'setSelectionRange' on 'HTMLInputElement': The input element's type ('email') does not support selection.
    at Error (native)
    at FastClick.focus (webpack:///./~/fastclick/lib/fastclick.js?:331:18)
    at FastClick.onTouchEnd (webpack:///./~/fastclick/lib/fastclick.js?:579:9)
    at HTMLBodyElement.methods (webpack:///./~/fastclick/lib/fastclick.js?:111:38)"
```

Thus I've replaced the `if()` check with a try/catch. Imho that's a better solution than to maintain a list of input fields that don't support text selection.

However, it seems like this whole selection fix is not necessary anymore on iOS 8 (as far as I've tested it). #43 Don't know what your policy is about old OS versions though... 
