### PR TITLE
IE10: Fixed typo in prefixed CSS property name relevant to IE10 support.

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -789,7 +789,7 @@
 		}
 
 		// IE10 with -ms-touch-action: none or manipulation, which disables double-tap-to-zoom (issue #97)
-		if (layer.style.msTouchAction === 'none' || layer.style.touchAction === 'manipulation') {
+		if (layer.style.msTouchAction === 'none' || layer.style.msTouchAction === 'manipulation') {
 			return true;
 		}
 


### PR DESCRIPTION
There is a typo in property name which affects `notNeeded` function when executed in IE10.
