### PR TITLE
Modulizr fix for master

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -835,7 +835,7 @@
 	} else if (typeof module !== 'undefined' && module.exports) {
 		module.exports = FastClick.attach;
 		module.exports.FastClick = FastClick;
-	} else {
-		window.FastClick = FastClick;
 	}
+	
+	window.FastClick = FastClick;
 }());

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -829,7 +829,7 @@
 	if (typeof define === 'function' && typeof define.amd === 'object' && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define(function() {
+		define('fastclick', function() {
 			return FastClick;
 		});
 	} else if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
This is to fix Fastclick on pages where uitk is not using Modulizr yet, but the page uses it for other parts. In that case, Fastclick has to be available for core, but it also needs to be defined as a module (with an ID)