### PR TITLE
Don't send synthetic clicks to contentEditable areas

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -248,9 +248,15 @@
 		case 'iframe': // iOS8 homescreen apps can prevent events bubbling into frames
 		case 'video':
 			return true;
-		}
+		default:
+			// Don't send a synthetic click to contentEditable elements (issue #127)
+			if (target.isContentEditable) {
+				return true;
+			}
 
-		return (/\bneedsclick\b/).test(target.className);
+			// Don't send a synthetic click to elements with the "needsclick" class
+			return (/\bneedsclick\b/).test(target.className);
+		}
 	};
 
 


### PR DESCRIPTION
This is a fix for Issue #127 based on the current 1.0.6 release.

ContentEditable areas don't play nicely with fastclick.  Either the keyboard opens and closes every time the cursor is moved or the cursor won't move at all.  There's a JSFiddle here which shows the problem:

https://jsfiddle.net/L9cxsqvu/4/

And with the fix applied:

https://jsfiddle.net/L9cxsqvu/8/
