### PR TITLE
Allow user to define function for determining if target needs click

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -102,6 +102,13 @@
 		 */
 		this.tapTimeout = options.tapTimeout || 700;
 
+		/**
+		 * Function determining whether or not a touched node needs click event.
+		 *
+		 * @type function(touch event target) -> boolean
+		 */
+		this.doesNeedClick = options.doesNeedClick || null;
+
 		if (FastClick.notNeeded(layer)) {
 			return;
 		}
@@ -248,6 +255,12 @@
 		case 'iframe': // iOS8 homescreen apps can prevent events bubbling into frames
 		case 'video':
 			return true;
+		}
+
+		if (typeof this.doesNeedClick === 'function') {
+			if (this.doesNeedClick(target) === true) {
+				return true;
+			}
 		}
 
 		return (/\bneedsclick\b/).test(target.className);


### PR DESCRIPTION
This grants more flexibility than adding a "needsclick" class, which was needed in my case (dealing with elements dynamically-generated by a third-party library).
