### PR TITLE
Issue #358, InvalidStateError when input is focused 

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -326,7 +326,8 @@
 		var length;
 
 		// Issue #160: on iOS 7, some input elements (e.g. date datetime month) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
-		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month') {
+		// Issue #358 same problem for input[type=number] and input[type=email]
+		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month' && targetElement.type !== 'number' && targetElement.type !== 'email') {
 			length = targetElement.value.length;
 			targetElement.setSelectionRange(length, length);
 		} else {


### PR DESCRIPTION
When input type is number or email is focused, an InvalidStateError is raised because of setSelectionRange
