### PR TITLE
Handle invalid dom element, fixes #371

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -822,6 +822,10 @@
 	 * @param {Object} [options={}] The options to override the defaults
 	 */
 	FastClick.attach = function(layer, options) {
+		if (!layer) {
+			return;
+		}
+		
 		return new FastClick(layer, options);
 	};
 


### PR DESCRIPTION
This fixes https://github.com/ftlabs/fastclick/issues/371 since that happens if the `layer` is null or undefined.