### PR TITLE
Add a new option to override needsclick check (addresses #141)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ Sometimes you need FastClick to ignore certain elements. You can do this easily 
 <a class="needsclick">Ignored by FastClick</a>
 ```
 
+You can also provide a custom function to evaluate whether a click is needed, through the `needsclick` option. The default needsclick function fixes some known issues so your custom function should typically still call `this.defaultNeedsClick`.
+```js
+    FastClick.attach(document.body, {
+        needsClick: function(target) {
+            return this.defaultNeedsClick(target) || (/\balsoneedsclick\b/).test(target.className);
+        }
+    });
+```
+
 #### Use case 1: non-synthetic click required ####
 
 Internally, FastClick uses `document.createEvent` to fire a synthetic `click` event as soon as `touchend` is fired by the browser. It then suppresses the additional `click` event created by the browser after that. In some cases, the non-synthetic `click` event created by the browser is required, as described in the [triggering focus example](http://ftlabs.github.com/fastclick/examples/focus.html).

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -102,6 +102,13 @@
 		 */
 		this.tapTimeout = options.tapTimeout || 700;
 
+		/**
+		 * Override for needsClick check function
+		 *
+		 * @type Function
+		 */
+		this.needsClick = options.needsClick || this.defaultNeedsClick;
+
 		if (FastClick.notNeeded(layer)) {
 			return;
 		}
@@ -224,7 +231,7 @@
 	 * @param {EventTarget|Element} target Target DOM element
 	 * @returns {boolean} Returns true if the element needs a native click
 	 */
-	FastClick.prototype.needsClick = function(target) {
+	FastClick.prototype.defaultNeedsClick = function(target) {
 		switch (target.nodeName.toLowerCase()) {
 
 		// Don't send a synthetic click to disabled inputs (issue #62)

--- a/tests/85.html
+++ b/tests/85.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<style type="text/css">
+    p, label { font-family: sans-serif; }
+</style>
+<title>#84</title>
+<script type="application/javascript" src="../lib/fastclick.js"></script>
+<script type="application/javascript">
+    window.addEventListener('load', function() {
+        document.addEventListener('click', function(evt){
+            if( evt.forwardedTouchEvent ) {
+                document.querySelector(".click-info").innerHTML += "forwarded touch event";
+            } else {
+                document.querySelector(".click-info").innerHTML += "natural click event";
+            }
+        });
+
+        new FastClick(document.body, {
+            needsClick: function(target) {
+                return this.defaultNeedsClick(target) || (/\balsoneedsclick\b/).test(target.className);
+            }
+        });
+    }, false);
+</script>
+</head>
+<body>
+    <p>Link with a class like "alsoneedsclick" will also permit clicks</p>
+    <a href="#" class="needsclick">Regular .needsclick</a> |
+    <a href="#" class="alsoneedsclick">.alsoneedsclick using overridden needsClick function</a> |
+    <a href="#">Regular link</a>
+    <div class="click-info"></div>
+</body>
+</html>


### PR DESCRIPTION
Some environments have idiosyncratic needsclick needs, e.g. since FastClick depends on adding `forwardedTouchEvent` to a click event, clicks can get lost in situations where that event gets resynthesized by other JS.

`options.needsclick` provides a generic hook for working around environment-idiosyncratic scenarios, allowing a custom `needsclick` function.

This lets people using FastClick in esoteric environments customize this check for their needs en masse, rather than being diligent about adding `needsclick` classes. It also lets folks with newly discovered issues engineer temporary workarounds without modifying their copy of fastclick.js
