### PR TITLE
needsclick can be applied to a tree of dom nodes, not just a single node

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -252,7 +252,7 @@
 
 		var foundClass = false;
 		var el = target;
-		while (el !== document && !foundClass) {
+		while (el && el !== document && !foundClass) {
 			foundClass = (/\bneedsclick\b/).test(el.className);
 			el = el.parentNode;
 		}

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -250,7 +250,13 @@
 			return true;
 		}
 
-		return (/\bneedsclick\b/).test(target.className);
+		var foundClass = false;
+		var el = target;
+		while (el !== document && !foundClass) {
+			foundClass = (/\bneedsclick\b/).test(el.className);
+			el = el.parentNode;
+		}
+		return foundClass;
 	};
 
 


### PR DESCRIPTION
The change makes `.needsclick`'s effect to be applied to a whole container.
I needed this as some libraries implement a similar behavior like fastclick and it causes double clicks. e.g: [reveal.js](https://github.com/hakimel/reveal.js/), [highcharts](https://github.com/highslide-software/highcharts.com)

fixes #302
