### PR TITLE
prevent unexpected click on stopping momentum scroll

### DIFF
--- a/examples/scroll.html
+++ b/examples/scroll.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="HandheldFriendly" content="True">
+  <meta name="MobileOptimized" content="320">
+  <meta http-equiv="cleartype" content="on">
+  <meta name="viewport" content="user-scalable=no, initial-scale=1.0, maximum-scale=1.0, width=device-width">
+  <title>Fastclick test</title>
+  <script type="application/javascript" src="../lib/fastclick.js"></script> 
+
+  <style>
+    ul {
+      padding-left: 0;
+      list-style: none;
+    }
+    li {
+      display: block;
+      padding: 10px;
+      border-bottom: 1px solid #eee;
+      margin-left: 0;
+    }
+    li:active {
+      background: #f8f8f8;
+    }
+    li.clicked {
+      background: #555;
+      color: white;
+    }
+  </style>
+</head>
+<body>
+  <ul>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+    <li>list</li>
+  </ul>
+</body>
+  <script>
+    FastClick.attach(document.body);
+    
+    var lis = document.querySelectorAll('li');
+    for (var i = 0; i < lis.length; i++) {
+      var element = lis[i];
+      element.onclick = function(e) {
+        e.target.classList.add('clicked');
+      };
+    }
+  </script>
+</html>

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -171,6 +171,17 @@
 			}, false);
 			layer.onclick = null;
 		}
+
+		// tracking the page scrolling state
+		window.isScrolling = false;
+		window.scorllTimeout = null;
+		window.onscroll = function() {
+			window.isScrolling = true;
+			clearTimeout(window.scrollTimeout);
+			window.scrollTimeout = setTimeout(function() {
+				window.isScrolling = false;
+			}, 100);
+		};
 	}
 
 	/**
@@ -389,6 +400,11 @@
 	 * @returns {boolean}
 	 */
 	FastClick.prototype.onTouchStart = function(event) {
+		if (window.isScrolling) {
+			clearTimeout(window.scrollTimeout);
+			return true;
+		}
+
 		var targetElement, touch, selection;
 
 		// Ignore multiple touches, otherwise pinch-to-zoom is prevented if both fingers are on the FastClick element (issue #111).
@@ -519,6 +535,10 @@
 	 * @returns {boolean}
 	 */
 	FastClick.prototype.onTouchEnd = function(event) {
+		if (window.isScrolling) {
+			window.isScrolling = false;
+			return true;
+		}
 		var forElement, trackingClickStart, targetTagName, scrollParent, touch, targetElement = this.targetElement;
 
 		if (!this.trackingClick) {


### PR DESCRIPTION
This is workaround by adding a global variable that tracking if page is scrolling. If is scrolling, cancel the click. 

Tested with examples/scroll.html on iOS safari 
