### PR TITLE
Linting cleanup - strings use single quote & explicit array items

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -178,7 +178,7 @@
 	*
 	* @type boolean
 	*/
-	var deviceIsWindowsPhone = navigator.userAgent.indexOf("Windows Phone") >= 0;
+	var deviceIsWindowsPhone = navigator.userAgent.indexOf('Windows Phone') >= 0;
 
 	/**
 	 * Android requires exceptions.
@@ -743,7 +743,7 @@
 		}
 
 		// Chrome version - zero for other browsers
-		chromeVersion = +(/Chrome\/([0-9]+)/.exec(navigator.userAgent) || [,0])[1];
+		chromeVersion = +(/Chrome\/([0-9]+)/.exec(navigator.userAgent) || [null,0])[1];
 
 		if (chromeVersion) {
 
@@ -794,7 +794,7 @@
 		}
 
 		// Firefox version - zero for other browsers
-		firefoxVersion = +(/Firefox\/([0-9]+)/.exec(navigator.userAgent) || [,0])[1];
+		firefoxVersion = +(/Firefox\/([0-9]+)/.exec(navigator.userAgent) || [null,0])[1];
 
 		if (firefoxVersion >= 27) {
 			// Firefox 27+ does not have tap delay if the content is not zoomable - https://bugzilla.mozilla.org/show_bug.cgi?id=922896


### PR DESCRIPTION
Address issues from JSHint static code analysis:
- Strings to single quote
- Explicit null entry in arrays: [,0] => [null,0]
