### PR TITLE
Add activeElement blur method check

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -295,7 +295,7 @@
 		var clickEvent, touch;
 
 		// On some Android devices activeElement needs to be blurred otherwise the synthetic click will have no effect (#24)
-		if (document.activeElement && document.activeElement !== targetElement) {
+		if (document.activeElement && document.activeElement !== targetElement && document.activeElement.blur) {
 			document.activeElement.blur();
 		}
 


### PR DESCRIPTION
Windows Phone 8.1 does not support blur event on activeElement.
This patch would prevent this kind of devices throwing error for blur invocation.

```
  Message: Object doesn't support property or method 'blur'
     at document line 301, column 3 (/sources//jspm_packages/npm/fastclick@1.0.6/lib/fastclick.js:301)

  Environment:
  Browser width	320	
  Browser height	489	
  Screen width	        377	
  Screen height	628	
  OS	Windows Phone 8.1
  Browser	IEMobile 11.0
```