### PR TITLE
Fixed fastclick stop to send "click" event after setting system clock back.

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -442,7 +442,7 @@
 		this.touchStartY = touch.pageY;
 
 		// Prevent phantom clicks on fast double-tap (issue #36)
-		if ((event.timeStamp - this.lastClickTime) < this.tapDelay) {
+		if ((event.timeStamp - this.lastClickTime) < this.tapDelay && (event.timeStamp - this.lastClickTime) > -1) {
 			event.preventDefault();
 		}
 
@@ -526,7 +526,7 @@
 		}
 
 		// Prevent phantom clicks on fast double-tap (issue #36)
-		if ((event.timeStamp - this.lastClickTime) < this.tapDelay) {
+		if ((event.timeStamp - this.lastClickTime) < this.tapDelay && (event.timeStamp - this.lastClickTime) > -1) {
 			this.cancelNextClick = true;
 			return true;
 		}


### PR DESCRIPTION
Fixed #225.
I think that it's better to use performance.now() instead of event.timeStamp, but window.performance object is not supported on iOS8. Thus I just add workaround code.
