### PR TITLE
Add 'email' to list of no-setSelectionRange

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -326,7 +326,7 @@
 		var length;
 
 		// Issue #160: on iOS 7, some input elements (e.g. date datetime month) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
-		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month') {
+		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month' && targetElement.type !== 'email') {
 			length = targetElement.value.length;
 			targetElement.setSelectionRange(length, length);
 		} else {


### PR DESCRIPTION
The error mentioned also gets thrown if we try to `setSelectionRange` on an input type email.
