### PR TITLE
Fix unsupported selection error

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -587,7 +587,7 @@
 
 			// Select elements need the event to go through on iOS 4, otherwise the selector menu won't open.
 			// Also this breaks opening selects when VoiceOver is active on iOS6, iOS7 (and possibly others)
-			if (!deviceIsIOS || targetTagName !== 'select') {
+			if (!deviceIsIOS4 || targetTagName !== 'select') {
 				this.targetElement = null;
 				event.preventDefault();
 			}

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -327,7 +327,7 @@
 
 		// Issue #160: on iOS 7, some input elements (e.g. date datetime month) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
 		// Issue #358: on iOS devices input elements throws an InvalidStateError when failing to execute setSelectionRange on an 'HTMLInputElement' that doesn't support selection.
-    var unsupportedTypes = ['time', 'month', 'number'];
+    var unsupportedTypes = ['time', 'month', 'number', 'email'];
 
 		if (deviceIsIOS &&
 		    targetElement.setSelectionRange &&

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -326,7 +326,13 @@
 		var length;
 
 		// Issue #160: on iOS 7, some input elements (e.g. date datetime month) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
-		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month') {
+		// Issue #358: on iOS devices input elements throws an InvalidStateError when failing to execute setSelectionRange on an 'HTMLInputElement' that doesn't support selection.
+    var unsupportedTypes = ['time', 'month', 'number'];
+
+		if (deviceIsIOS &&
+		    targetElement.setSelectionRange &&
+		    targetElement.type.indexOf('date') !== 0 &&
+        unsupportedTypes.indexOf(targetElement.type) === -1) {
 			length = targetElement.value.length;
 			targetElement.setSelectionRange(length, length);
 		} else {

--- a/tests/358.html
+++ b/tests/358.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<style type="text/css">
+	p { font-family: sans-serif; }
+</style>
+<title>#160</title>
+<script type="application/javascript" src="../lib/fastclick.js"></script>
+<script type="application/javascript">
+	window.addEventListener('load', function() {
+		FastClick.attach(document.body);
+	}, false);
+</script>
+</head>
+<body>
+	<p>Calling elem.setSelectionRange on inputs with type number throws an InvalidStateError.</p>
+	<form>
+		<p>Test:</p>
+		<input type="number" name="test">
+		<p>Control:</p>
+		<input name="control">
+	</form>
+</body>
+</html>

--- a/tests/358.html
+++ b/tests/358.html
@@ -16,8 +16,10 @@
 <body>
 	<p>Calling elem.setSelectionRange on inputs with type number throws an InvalidStateError.</p>
 	<form>
-		<p>Test:</p>
+		<p>Test (number):</p>
 		<input type="number" name="test">
+		<p>Test (email):</p>
+		<input type="email" name="test">
 		<p>Control:</p>
 		<input name="control">
 	</form>


### PR DESCRIPTION
Fixes issue #358 for which an uncaught `InvalidStateError` occurs on iOS devices when selecting an input with type `number`.
