### PR TITLE
Update readme to have newer browser standards.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For IE11+, you can use `touch-action: manipulation;` to disable double-tap-to-zo
 Include fastclick.js in your JavaScript bundle or add it to your HTML page like this:
 
 ```html
-<script type='application/javascript' src='/path/to/fastclick.js'></script>
+<script src="/path/to/fastclick.js"></script>
 ```
 
 The script must be loaded prior to instantiating FastClick on any element of the page.
@@ -52,11 +52,9 @@ The script must be loaded prior to instantiating FastClick on any element of the
 To instantiate FastClick on the `body`, which is the recommended method of use:
 
 ```js
-if ('addEventListener' in document) {
-	document.addEventListener('DOMContentLoaded', function() {
-		FastClick.attach(document.body);
-	}, false);
-}
+document.addEventListener('DOMContentLoaded', function() {
+	FastClick.attach(document.body);
+}, false);
 ```
 
 Or, if you're using jQuery:


### PR DESCRIPTION
IE8 is not supported so checking if `addEventListener` is on the `document` isn't necessary.

[Browser Compatibility](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Browser_compatibility)
[IE Support](https://support.microsoft.com/en-us/gp/microsoft-internet-explorer)

The `type` attribute hasn't been needed since 1995.

> The default, which is used if the attribute is absent, is "text/javascript".

[Source](http://www.w3.org/TR/html5/scripting-1.html#the-script-element)