### PR TITLE
Google places fix

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -102,6 +102,13 @@
 		 */
 		this.tapTimeout = options.tapTimeout || 700;
 
+                /**
+                 * A node to exclude based on className. Alternative to manually applying needsclick.
+                 *
+                 * @type string
+                 */
+                this.excludeNode = options.excludeNode || null;
+
 		if (FastClick.notNeeded(layer)) {
 			return;
 		}
@@ -250,7 +257,7 @@
 			return true;
 		}
 
-		return (/\bneedsclick\b/).test(target.className);
+		return ((/\bneedsclick\b/).test(target.className) || (new RegExp(this.excludeNode).test(target.className)));
 	};
 
 


### PR DESCRIPTION
This fix allows you to add a regexp for classes that get the same treatment as `needsclick`.  For fixing the google places problem on iPhone, you need to do:
```
FastClick.attach(document.body, {
        excludeNode: '^pac-',
    });
```

It is advisable to also add this to the css:
```
 .pac-item span {  
        pointer-events: none;
    }
```