### PR TITLE
Added a test for class="nofastclick" to ignore all children nodes.

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -250,7 +250,16 @@
 			return true;
 		}
 
-		return (/\bneedsclick\b/).test(target.className);
+		if ((/\bneedsclick\b/).test(target.className))
+			return true;
+
+		var el = target;
+	    while (el.parentNode) {
+	        el = el.parentNode;
+	        if ((/\bnofastclick\b/).test(el.className))
+	            return true;
+	    }
+	    return false;
 	};
 
 


### PR DESCRIPTION
This approach of using nofastclick to ignore children nodes,
preserves the functionality of needsclick only applying to the
existing node.

A work-around for https://github.com/ftlabs/fastclick/issues/447
