### PR TITLE
Adding the fix where tap to focus now works on contenteditable elements.

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -399,6 +399,11 @@
 		targetElement = this.getTargetElementFromEventTarget(event.target);
 		touch = event.targetTouches[0];
 
+		// Ignore touches on contenteditable elements to prevent conflict with text selection (issue #127).
+		if (targetElement.isContentEditable) {
+			return true;
+		}
+
 		if (deviceIsIOS) {
 
 			// Only trusted events will deselect text on iOS (issue #49)


### PR DESCRIPTION
Currently, with fastclick enabled, when we try to tap on a contenteditable element, focus is not put into the element. Adding this fix, enables the tap to focus to work.

Created the PR after testing the fix as mentioned here - https://github.com/skinandbones/fastclick/commit/9ba514fa0ed8438f2ec87f93e8c1236f622892d5

References issue - https://github.com/ftlabs/fastclick/issues/396
