### PR TITLE
Blur active element only on Android devices

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -295,7 +295,7 @@
 		var clickEvent, touch;
 
 		// On some Android devices activeElement needs to be blurred otherwise the synthetic click will have no effect (#24)
-		if (document.activeElement && document.activeElement !== targetElement) {
+		if (deviceIsAndroid && document.activeElement && document.activeElement !== targetElement) {
 			document.activeElement.blur();
 		}
 


### PR DESCRIPTION
On iPhones, a click on editable content, attached to FastClick, would unexpectedly dismiss the keyboard. Not blurring the active element fixes the problem.
