### PR TITLE
check input type include 'number' before `setSelectionRange`

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -326,7 +326,7 @@
 		var length;
 
 		// Issue #160: on iOS 7, some input elements (e.g. date datetime month) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
-		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month') {
+		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month' && targetElement.type !== 'number') {
 			length = targetElement.value.length;
 			targetElement.setSelectionRange(length, length);
 		} else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastclick",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Polyfill to remove click delays on browsers with touch UIs.",
   "maintainers": [
     {


### PR DESCRIPTION
see: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange

```
Note that accordingly to the WHATWG forms spec selectionStart, selectionEnd properties and 
setSelectionRange method apply only to inputs of types text, search, URL, tel and password. Chrome, 
starting from version 33, throws an exception while accessing those properties and method on the rest of 
input types. For example, on input of type number: "Failed to read the 'selectionStart' property from 
'HTMLInputElement': The input element's type ('number') does not support selection."
```
