### PR TITLE
Compensate for accidental screen nudge while tapping

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -519,7 +519,9 @@
 	 * @returns {boolean}
 	 */
 	FastClick.prototype.onTouchEnd = function(event) {
-		var forElement, trackingClickStart, targetTagName, scrollParent, touch, targetElement = this.targetElement;
+        var forElement, trackingClickStart, targetTagName, scrollParent, scrollAmount, touch,
+            targetElement = this.targetElement,
+            boundary = this.touchBoundary;
 
 		if (!this.trackingClick) {
 			return true;
@@ -594,9 +596,15 @@
 			// Don't send a synthetic click event if the target element is contained within a parent layer that was scrolled
 			// and this tap is being used to stop the scrolling (usually initiated by a fling - issue #42).
 			scrollParent = targetElement.fastClickScrollParent;
-			if (scrollParent && scrollParent.fastClickLastScrollTop !== scrollParent.scrollTop) {
-				return true;
-			}
+            if (scrollParent) {
+                // Allow a small amount of scrolling equal to the touchBoundary option.
+                // Users often nudge the scroll position by accident while tapping,
+                // so we should not prevent those taps from going through (issue #462)
+                scrollAmount = Math.abs(scrollParent.fastClickLastScrollTop - scrollParent.scrollTop);
+                if (scrollAmount > boundary) {
+                    return true;
+                }
+            }
 		}
 
 		// Prevent the actual click from going though - unless the target node is marked as requiring

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -593,9 +593,9 @@
 
 		if (deviceIsIOS && !deviceIsIOS4) {
 
-			// Don't send a synthetic click event if the target element is contained within a parent layer that was scrolled
-			// and this tap is being used to stop the scrolling (usually initiated by a fling - issue #42).
-			scrollParent = targetElement.fastClickScrollParent;
+            // Don't send a synthetic click event if the target element is contained within a parent layer that was scrolled
+            // and this tap is being used to stop the scrolling (usually initiated by a fling - issue #42).
+            scrollParent = targetElement.fastClickScrollParent;
             if (scrollParent) {
                 // Allow a small amount of scrolling equal to the touchBoundary option.
                 // Users often nudge the scroll position by accident while tapping,

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -519,9 +519,9 @@
 	 * @returns {boolean}
 	 */
 	FastClick.prototype.onTouchEnd = function(event) {
-        var forElement, trackingClickStart, targetTagName, scrollParent, scrollAmount, touch,
-            targetElement = this.targetElement,
-            boundary = this.touchBoundary;
+            var forElement, trackingClickStart, targetTagName, scrollParent, scrollAmount, touch,
+                targetElement = this.targetElement,
+                boundary = this.touchBoundary;
 
 		if (!this.trackingClick) {
 			return true;
@@ -593,18 +593,18 @@
 
 		if (deviceIsIOS && !deviceIsIOS4) {
 
-            // Don't send a synthetic click event if the target element is contained within a parent layer that was scrolled
-            // and this tap is being used to stop the scrolling (usually initiated by a fling - issue #42).
-            scrollParent = targetElement.fastClickScrollParent;
-            if (scrollParent) {
-                // Allow a small amount of scrolling equal to the touchBoundary option.
-                // Users often nudge the scroll position by accident while tapping,
-                // so we should not prevent those taps from going through (issue #462)
-                scrollAmount = Math.abs(scrollParent.fastClickLastScrollTop - scrollParent.scrollTop);
-                if (scrollAmount > boundary) {
-                    return true;
+                // Don't send a synthetic click event if the target element is contained within a parent layer that was scrolled
+                // and this tap is being used to stop the scrolling (usually initiated by a fling - issue #42).
+                scrollParent = targetElement.fastClickScrollParent;
+                if (scrollParent) {
+                    // Allow a small amount of scrolling equal to the touchBoundary option.
+                    // Users often nudge the scroll position by accident while tapping,
+                    // so we should not prevent those taps from going through (issue #462)
+                    scrollAmount = Math.abs(scrollParent.fastClickLastScrollTop - scrollParent.scrollTop);
+                    if (scrollAmount > boundary) {
+                        return true;
+                    }
                 }
-            }
 		}
 
 		// Prevent the actual click from going though - unless the target node is marked as requiring

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -593,18 +593,18 @@
 
 		if (deviceIsIOS && !deviceIsIOS4) {
 
-                    // Don't send a synthetic click event if the target element is contained within a parent layer that was scrolled
-                    // and this tap is being used to stop the scrolling (usually initiated by a fling - issue #42).
-                    scrollParent = targetElement.fastClickScrollParent;
-                    if (scrollParent) {
-                        // Allow a small amount of scrolling equal to the touchBoundary option.
-                        // Users often nudge the scroll position by accident while tapping,
-                        // so we should not prevent those taps from going through (issue #462)
-                        scrollAmount = Math.abs(scrollParent.fastClickLastScrollTop - scrollParent.scrollTop);
-                        if (scrollAmount > boundary) {
-                            return true;
+                        // Don't send a synthetic click event if the target element is contained within a parent layer that was scrolled
+                        // and this tap is being used to stop the scrolling (usually initiated by a fling - issue #42).
+                        scrollParent = targetElement.fastClickScrollParent;
+                        if (scrollParent) {
+                            // Allow a small amount of scrolling equal to the touchBoundary option.
+                            // Users often nudge the scroll position by accident while tapping,
+                            // so we should not prevent those taps from going through (issue #462)
+                            scrollAmount = Math.abs(scrollParent.fastClickLastScrollTop - scrollParent.scrollTop);
+                            if (scrollAmount > boundary) {
+                                return true;
+                            }
                         }
-                    }
 		}
 
 		// Prevent the actual click from going though - unless the target node is marked as requiring

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -593,18 +593,18 @@
 
 		if (deviceIsIOS && !deviceIsIOS4) {
 
-                        // Don't send a synthetic click event if the target element is contained within a parent layer that was scrolled
-                        // and this tap is being used to stop the scrolling (usually initiated by a fling - issue #42).
-                        scrollParent = targetElement.fastClickScrollParent;
-                        if (scrollParent) {
-                            // Allow a small amount of scrolling equal to the touchBoundary option.
-                            // Users often nudge the scroll position by accident while tapping,
-                            // so we should not prevent those taps from going through (issue #462)
-                            scrollAmount = Math.abs(scrollParent.fastClickLastScrollTop - scrollParent.scrollTop);
-                            if (scrollAmount > boundary) {
-                                return true;
-                            }
-                        }
+                       // Don't send a synthetic click event if the target element is contained within a parent layer that was scrolled
+                       // and this tap is being used to stop the scrolling (usually initiated by a fling - issue #42).
+                       scrollParent = targetElement.fastClickScrollParent;
+                       if (scrollParent) {
+                           // Allow a small amount of scrolling equal to the touchBoundary option.
+                           // Users often nudge the scroll position by accident while tapping,
+                           // so we should not prevent those taps from going through (issue #462)
+                           scrollAmount = Math.abs(scrollParent.fastClickLastScrollTop - scrollParent.scrollTop);
+                           if (scrollAmount > boundary) {
+                               return true;
+                           }
+                       }
 		}
 
 		// Prevent the actual click from going though - unless the target node is marked as requiring

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -519,9 +519,9 @@
 	 * @returns {boolean}
 	 */
 	FastClick.prototype.onTouchEnd = function(event) {
-            var forElement, trackingClickStart, targetTagName, scrollParent, scrollAmount, touch,
-                targetElement = this.targetElement,
-                boundary = this.touchBoundary;
+               var forElement, trackingClickStart, targetTagName, scrollParent, scrollAmount, touch,
+                   targetElement = this.targetElement,
+                   boundary = this.touchBoundary;
 
 		if (!this.trackingClick) {
 			return true;
@@ -593,18 +593,18 @@
 
 		if (deviceIsIOS && !deviceIsIOS4) {
 
-                // Don't send a synthetic click event if the target element is contained within a parent layer that was scrolled
-                // and this tap is being used to stop the scrolling (usually initiated by a fling - issue #42).
-                scrollParent = targetElement.fastClickScrollParent;
-                if (scrollParent) {
-                    // Allow a small amount of scrolling equal to the touchBoundary option.
-                    // Users often nudge the scroll position by accident while tapping,
-                    // so we should not prevent those taps from going through (issue #462)
-                    scrollAmount = Math.abs(scrollParent.fastClickLastScrollTop - scrollParent.scrollTop);
-                    if (scrollAmount > boundary) {
-                        return true;
+                    // Don't send a synthetic click event if the target element is contained within a parent layer that was scrolled
+                    // and this tap is being used to stop the scrolling (usually initiated by a fling - issue #42).
+                    scrollParent = targetElement.fastClickScrollParent;
+                    if (scrollParent) {
+                        // Allow a small amount of scrolling equal to the touchBoundary option.
+                        // Users often nudge the scroll position by accident while tapping,
+                        // so we should not prevent those taps from going through (issue #462)
+                        scrollAmount = Math.abs(scrollParent.fastClickLastScrollTop - scrollParent.scrollTop);
+                        if (scrollAmount > boundary) {
+                            return true;
+                        }
                     }
-                }
 		}
 
 		// Prevent the actual click from going though - unless the target node is marked as requiring


### PR DESCRIPTION
Many users seem to have trouble tapping buttons or links because they accidentally scroll slightly while tapping (see issue #462). Make tapping more friendly by allowing a small amount of scrolling equal to the touchBoundary before ignoring the tap.
