### PR TITLE
Update README.md with new build URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ attachFastClick(document.body);
 
 ### Minified ###
 
-Run `make` to build a minified version of FastClick using the Closure Compiler REST API. The minified file is saved to `build/fastclick.min.js` or you can [download a pre-minified version](http://build.origami.ft.com/bundles/js?modules=fastclick).
+Run `make` to build a minified version of FastClick using the Closure Compiler REST API. The minified file is saved to `build/fastclick.min.js` or you can [download a pre-minified version](https://origami-build.ft.com/bundles/js?modules=fastclick).
 
 Note: the pre-minified version is built using [our build service](http://origami.ft.com/docs/developer-guide/build-service/) which exposes the `FastClick` object through `Origami.fastclick` and will have the Browserify/CommonJS API (see above).
 


### PR DESCRIPTION
Only a minor change. Probably does not need testing :)

Origami Build Service is migrating from Akamai to Fastly.