### PR TITLE
Fixed incorrect documentation on AMD/require.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ $(function() {
 If you're using Browserify or another CommonJS-style module system, the `FastClick.attach` function will be returned when you call `require('fastclick')`. As a result, the easiest way to use FastClick with these loaders is as follows:
 
 ```js
-var attachFastClick = require('fastclick');
-attachFastClick(document.body);
+var fastClick = require('fastclick');
+fastClick.attach(document.body);
 ```
 
 ### Minified ###


### PR DESCRIPTION
The documentation incorrectly states that in a require.js (or other CommonJS module system) that 'FastClick.attach' will be returned, however in reality the object itself is returned, and .attach must be called. 

eg
`require('fastclick').attach(document.body);`

**Expected behaviour:**
FastClick.attach returned as documented.

**Actual behaviour:**
FastClick returned.

**Patch Fix:**
Update documentation, code is fine as is.
