### PR TITLE
Fix bug: When the textarea focus, the cursor position is incorrect

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -583,7 +583,10 @@
 			// Also this breaks opening selects when VoiceOver is active on iOS6, iOS7 (and possibly others)
 			if (!deviceIsIOS || targetTagName !== 'select') {
 				this.targetElement = null;
-				event.preventDefault();
+				// Fix bug: When the textarea focus, the cursor position is incorrect
+				if (!(/\bneedsclick\b/).test(targetElement.className)) {
+					event.preventDefault();
+				}
 			}
 
 			return false;


### PR DESCRIPTION
When I click on the textarea, the focus position and my position is not the same as a click, it is always the end or start of the line.
