### PR TITLE
Fixing TypeError when targetElement is undefined. This fixes #471.

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -556,6 +556,12 @@
 			targetElement.fastClickScrollParent = this.targetElement.fastClickScrollParent;
 		}
 
+		// If targetElement is null then return out to stop errors.
+		// See issue #471;
+		if (typeof targetElement !== 'object' || targetElement === null) {
+			return false;
+		}
+
 		targetTagName = targetElement.tagName.toLowerCase();
 		if (targetTagName === 'label') {
 			forElement = this.findControl(targetElement);


### PR DESCRIPTION
As issue #471 states there are a lot of errors being reported when targetElement is not an object. This adds defensive coding around targetElement to check its a valid object before trying to obtain the targetElement.tagName
