### PR TITLE
Ignore child element recursively

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -225,6 +225,9 @@
 	 * @returns {boolean} Returns true if the element needs a native click
 	 */
 	FastClick.prototype.needsClick = function(target) {
+		var p = target;
+		var prevent = false;
+		
 		switch (target.nodeName.toLowerCase()) {
 
 		// Don't send a synthetic click to disabled inputs (issue #62)
@@ -250,7 +253,13 @@
 			return true;
 		}
 
-		return (/\bneedsclick\b/).test(target.className);
+		prevent = (/\bneedsclick\b/).test(target.className);
+
+		while(!prevent && (p = p.parentNode)) {
+			prevent = prevent || (/\bneedsclickchild\b/).test(p.className)
+		}
+
+		return prevent;
 	};
 
 


### PR DESCRIPTION
Sometimes we needs to ignore all elements of an element hierachy. So i propose to add a class named "needsclickchild".

JQuery does not work properly with fastClick, we cannot use sliders on mobile/touch devices. 
