### PR TITLE
add restore function for inverts destroy()

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -727,6 +727,27 @@
 
 
 	/**
+	 * Restore add all FastClick's event listeners.
+	 *
+	 * @returns {void}
+	 */
+	FastClick.prototype.restore = function() {
+		var layer = this.layer;
+
+		if (deviceIsAndroid) {
+			layer.addEventListener('mouseover', this.onMouse, true);
+			layer.addEventListener('mousedown', this.onMouse, true);
+			layer.addEventListener('mouseup', this.onMouse, true);
+		}
+
+		layer.addEventListener('click', this.onClick, true);
+		layer.addEventListener('touchstart', this.onTouchStart, false);
+		layer.addEventListener('touchmove', this.onTouchMove, false);
+		layer.addEventListener('touchend', this.onTouchEnd, false);
+		layer.addEventListener('touchcancel', this.onTouchCancel, false);
+	};
+
+	/**
 	 * Check whether FastClick is needed.
 	 *
 	 * @param {Element} layer The layer to listen on


### PR DESCRIPTION
 I called destory(), FastClick instance will be  unuseful and I have to new instance of FastClick to reuse FastClick in some time. In order to prevent new instance of FastClick,I add restore() to FastClick.prototype.
