### PR TITLE
Leverage touch-action whenever possible

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -808,8 +808,8 @@
 		// Browsers that support touch-action can just use that to disable double-tap.
 		// https://developers.google.com/web/updates/2013/12/300ms-tap-delay-gone-away?hl=en
 		if ('touchAction' in layer.style) {
-			// Only 'auto' (the default) has double-tap enabled
-			if (layer.style.touchAction === '' || layer.style.touchAction === 'auto') {
+			// Only 'auto' (the default) has double-tap enabled.
+			if (getComputedStyle(layer).touchAction === 'auto') {
 				layer.style.touchAction = 'manipulation';
 			}
 			return true;

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -789,7 +789,7 @@
 		}
 
 		// IE10 with -ms-touch-action: none or manipulation, which disables double-tap-to-zoom (issue #97)
-		if (layer.style.msTouchAction === 'none' || layer.style.touchAction === 'manipulation') {
+		if (layer.style.msTouchAction === 'none' || layer.style.msTouchAction === 'manipulation') {
 			return true;
 		}
 
@@ -805,9 +805,13 @@
 			}
 		}
 
-		// IE11: prefixed -ms-touch-action is no longer supported and it's recomended to use non-prefixed version
-		// http://msdn.microsoft.com/en-us/library/windows/apps/Hh767313.aspx
-		if (layer.style.touchAction === 'none' || layer.style.touchAction === 'manipulation') {
+		// Browsers that support touch-action can just use that to disable double-tap.
+		// https://developers.google.com/web/updates/2013/12/300ms-tap-delay-gone-away?hl=en
+		if ('touchAction' in layer.style) {
+			// Only 'auto' (the default) has double-tap enabled
+			if (layer.style.touchAction === '' || layer.style.touchAction === 'auto') {
+				layer.style.touchAction = 'manipulation';
+			}
 			return true;
 		}
 


### PR DESCRIPTION
If the browser supports `touch-action` then disable the tap delay explicitly by disabling the double-tap-to-zoom gesture and not installing touch listeners at all.

Setting `touch-action` to `manipulation` on an element (when not already set to something else) has no other impact than disabling double-tap (which normal FastClick code does anyway), so there shouldn't be much (any?) downside to this approach.  It has several advantages to the existing behavior:
- doesn't require the author to know they need to explicitly opt-in to touch-action
- avoids the [potential scroll performance impact](https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md) of installing non-passive touch listeners
- doesn't disable browser-defined tap recognition features such as touch adjustment (small target handling), tap suppression (don't click on a tap during a fling), system-defined slop regions (eg. different Android devices can have different configurations for how much movement is permitted for a 'tap').

Fixes #498
