### PR TITLE
Whitelist Selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Another example of when to use the `needsclick` class is with dropdowns in Twitt
 
 ### Whitelisting ###
 
-If you'd rather opt-in to using FastClick instead of using the `.needsclick` class, you can specify a CSS selector string that elements must must in order for FastClick's magic to be applied. For example:
+If you'd rather opt-in to using FastClick instead of using the `.needsclick` class, you can specify a CSS selector string that elements must match in order for FastClick's magic to be applied. For example:
 
 ```js
 FastClick.attach(document.body, {

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ For Ruby, there's a third-party gem called [fastclick-rails](http://rubygems.org
 ### Ignore certain elements with `needsclick` ###
 
 Sometimes you need FastClick to ignore certain elements. You can do this easily by adding the `needsclick` class.
+
 ```html
 <a class="needsclick">Ignored by FastClick</a>
 ```
@@ -122,6 +123,24 @@ Another example of when to use the `needsclick` class is with dropdowns in Twitt
 ```html
 <a class="dropdown-toggle needsclick" data-toggle="dropdown">Dropdown</a>
 ```
+
+### Whitelisting ###
+
+If you'd rather opt-in to using FastClick instead of using the `.needsclick` class, you can specify a CSS selector string that elements must must in order for FastClick's magic to be applied. For example:
+
+```js
+FastClick.attach(document.body, {
+    // only enable for elements with the .fastlcick class and their children
+    selector: '.fastclick, .fastclick *'
+});
+```
+
+```html
+<a>Ignored by FastClick</a>
+<a class="fastclick">Uses FastClick</a>
+```
+
+**Warning**: This does not work on all browser versions generally supported by FastClick. If you need to support devices that don't support [`element.matches()` or `element.matchesSelector()`](http://caniuse.com/#search=matches), you should not rely on this functionality. If a selector is specified for an unsupported browser, FastClick will disregard the selector and perform the default FastClick behavior.
 
 ## Examples ##
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Another example of when to use the `needsclick` class is with dropdowns in Twitt
 
 ### Whitelisting ###
 
-If you'd rather opt-in to using FastClick instead of using the `.needsclick` class, you can specify a CSS selector string that elements must match in order for FastClick's magic to be applied. For example:
+If you'd rather opt-in to using FastClick instead of opting out with the `.needsclick` class, you can specify a CSS selector that elements must match in order to make use of FastClick's magic. For example:
 
 ```js
 FastClick.attach(document.body, {
@@ -140,7 +140,7 @@ FastClick.attach(document.body, {
 <a class="fastclick">Uses FastClick</a>
 ```
 
-**Warning**: This does not work on all browser versions generally supported by FastClick. If you need to support devices that don't support [`element.matches()` or `element.matchesSelector()`](http://caniuse.com/#search=matches), you should not rely on this functionality. If a selector is specified for an unsupported browser, FastClick will disregard the selector and perform the default FastClick behavior.
+**Warning**: This does not work on all browser versions generally supported by FastClick. If you need to support devices that don't support [`element.matches()` or `element.matchesSelector()`](http://caniuse.com/#search=matches) (e.g., Android 2.1 and below, iOS 3 and below, etc.), you should **not rely on this functionality**. If a selector is specified for an unsupported browser, FastClick will disregard the selector and perform the default FastClick behavior.
 
 ## Examples ##
 

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -238,12 +238,10 @@
 		if (this.selector) {
 			var fnMatches = target.matches || target.matchesSelector || target.webkitMatchesSelector || target.mozMatchesSelector || target.msMatchesSelector || null;
 
-			if (fnMatches) {
-				if (!fnMatches.call(target, this.selector)) {
-					return true;
-				}
-			} else {
+			if (!fnMatches) {
 				console.error('Unsupported browser for whitelisting with Fastclick. Ignoring selector.')
+			} else if (!fnMatches.call(target, this.selector)) {
+				return true;
 			}
 		}
 

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -102,6 +102,14 @@
 		 */
 		this.tapTimeout = options.tapTimeout || 700;
 
+		/**
+		 * To whitelist specific elements, a selector string can be specified that will
+		 * limit the elements on which FastClick works.
+		 * 
+		 * @type {string}
+		 */
+		this.selector = options.selector || '';
+
 		if (FastClick.notNeeded(layer)) {
 			return;
 		}
@@ -225,6 +233,20 @@
 	 * @returns {boolean} Returns true if the element needs a native click
 	 */
 	FastClick.prototype.needsClick = function(target) {
+
+		// Require a click for all that don't match this.selector, if specified
+		if (this.selector) {
+			var fnMatches = target.matches || target.matchesSelector || target.webkitMatchesSelector || target.mozMatchesSelector || target.msMatchesSelector || null;
+
+			if (fnMatches) {
+				if (!fnMatches.call(target, this.selector)) {
+					return true;
+				}
+			} else {
+				console.error('Unsupported browser for whitelisting with Fastclick. Ignoring selector.')
+			}
+		}
+
 		switch (target.nodeName.toLowerCase()) {
 
 		// Don't send a synthetic click to disabled inputs (issue #62)


### PR DESCRIPTION
This adds support to opt-in to FastClick for elements matching a specified query selector. Instead of using `.needsclick` everywhere, FastClick can now apply itself only to elements matching `.fastclick`, for example:

``` js
FastClick.attach(document.body, {
    // only enable for elements with the .fastlcick class and their children
    selector: '.fastclick, .fastclick *'
});
```

``` html
<a>Ignored by FastClick</a>
<a class="fastclick">Uses FastClick</a>
```

I was previously using [SelectiveFastclick](https://github.com/matthew-andrews/selective-fastclick) to handle this, but it was causing some problems with scrolling on iOS, and it didn't make much sense to me to have the overhead of an entirely separate project for what should be a small feature.

Here are some GitHub issues that this may address:
- https://github.com/ftlabs/fastclick/issues/290
- https://github.com/ftlabs/fastclick/issues/109
- https://github.com/ftlabs/fastclick/pull/347
- https://github.com/ftlabs/fastclick/issues/488

Unfortunately, browser support for this is a bit more limited than FastClick, itself, so I've noted that in the README. This may be a deal-breaker (it wasn't for me), so hopefully this PR is at least helpful to someone even if it's not fully ready to merge.
