### PR TITLE
Update needsClick() to traverse up through its ancestors in the DOM tree

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -225,32 +225,44 @@
 	 * @returns {boolean} Returns true if the element needs a native click
 	 */
 	FastClick.prototype.needsClick = function(target) {
-		switch (target.nodeName.toLowerCase()) {
+		while (
+			target &&
+			target.nodeType !== Node.ELEMENT_NODE &&
+			target !== this.layer
+		) {
+			switch (target.nodeName.toLowerCase()) {
 
-		// Don't send a synthetic click to disabled inputs (issue #62)
-		case 'button':
-		case 'select':
-		case 'textarea':
-			if (target.disabled) {
+			// Don't send a synthetic click to disabled inputs (issue #62)
+			case 'button':
+			case 'select':
+			case 'textarea':
+				if (target.disabled) {
+					return true;
+				}
+
+				break;
+			case 'input':
+
+				// File inputs need real clicks on iOS 6 due to a browser bug (issue #68)
+				if ((deviceIsIOS && target.type === 'file') || target.disabled) {
+					return true;
+				}
+
+				break;
+			case 'label':
+			case 'iframe': // iOS8 homescreen apps can prevent events bubbling into frames
+			case 'video':
 				return true;
 			}
 
-			break;
-		case 'input':
-
-			// File inputs need real clicks on iOS 6 due to a browser bug (issue #68)
-			if ((deviceIsIOS && target.type === 'file') || target.disabled) {
+			if ((/\bneedsclick\b/).test(target.className)) {
 				return true;
 			}
 
-			break;
-		case 'label':
-		case 'iframe': // iOS8 homescreen apps can prevent events bubbling into frames
-		case 'video':
-			return true;
+			target = target.parentNode;
 		}
 
-		return (/\bneedsclick\b/).test(target.className);
+		return false;
 	};
 
 

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -227,7 +227,7 @@
 	FastClick.prototype.needsClick = function(target) {
 		while (
 			target &&
-			target.nodeType !== Node.ELEMENT_NODE &&
+			target.nodeType === Node.ELEMENT_NODE &&
 			target !== this.layer
 		) {
 			switch (target.nodeName.toLowerCase()) {


### PR DESCRIPTION
Resolves: https://github.com/ftlabs/fastclick/issues/119, https://github.com/ftlabs/fastclick/issues/316, https://github.com/ftlabs/fastclick/issues/377, https://github.com/ftlabs/fastclick/issues/447, https://github.com/ftlabs/fastclick/issues/460

Similar: https://github.com/ftlabs/fastclick/pull/403, https://github.com/ftlabs/fastclick/pull/448, https://github.com/ftlabs/fastclick/pull/468

However my pull-request will work also with children of `<button>` and `<label>` nodes, and will only climb the DOM tree until the layer node.


