### PR TITLE
removed onTouchMove event listener, so it will be more effective.

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -77,7 +77,7 @@
 		 *
 		 * @type number
 		 */
-		this.touchBoundary = options.touchBoundary || 5;
+		this.touchBoundary = options.touchBoundary || 10;
 
 
 		/**
@@ -102,7 +102,7 @@
 		this.tapTimeout = options.tapTimeout || 700;
 
 		if (FastClick.notNeeded(layer)) {
-			//return;
+			return;
 		}
 
 		// Some old versions of Android don't have Function.prototype.bind

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -1,4 +1,4 @@
-;(function () {
+(function () {
 	'use strict';
 
 	/**
@@ -11,7 +11,6 @@
 
 	/*jslint browser:true, node:true*/
 	/*global define, Event, Node*/
-
 
 	/**
 	 * Instantiate fast-clicking listeners on the specified layer.
@@ -78,7 +77,7 @@
 		 *
 		 * @type number
 		 */
-		this.touchBoundary = options.touchBoundary || 10;
+		this.touchBoundary = options.touchBoundary || 5;
 
 
 		/**
@@ -103,7 +102,7 @@
 		this.tapTimeout = options.tapTimeout || 700;
 
 		if (FastClick.notNeeded(layer)) {
-			return;
+			//return;
 		}
 
 		// Some old versions of Android don't have Function.prototype.bind
@@ -112,7 +111,7 @@
 		}
 
 
-		var methods = ['onMouse', 'onClick', 'onTouchStart', 'onTouchMove', 'onTouchEnd', 'onTouchCancel'];
+		var methods = ['onMouse', 'onClick', 'onTouchStart', 'onTouchEnd', 'onTouchCancel'];
 		var context = this;
 		for (var i = 0, l = methods.length; i < l; i++) {
 			context[methods[i]] = bind(context[methods[i]], context);
@@ -127,7 +126,6 @@
 
 		layer.addEventListener('click', this.onClick, true);
 		layer.addEventListener('touchstart', this.onTouchStart, false);
-		layer.addEventListener('touchmove', this.onTouchMove, false);
 		layer.addEventListener('touchend', this.onTouchEnd, false);
 		layer.addEventListener('touchcancel', this.onTouchCancel, false);
 
@@ -438,8 +436,8 @@
 		this.trackingClickStart = event.timeStamp;
 		this.targetElement = targetElement;
 
-		this.touchStartX = touch.pageX;
-		this.touchStartY = touch.pageY;
+		this.touchStartX = touch.clientX;
+		this.touchStartY = touch.clientY;
 
 		// Prevent phantom clicks on fast double-tap (issue #36)
 		if ((event.timeStamp - this.lastClickTime) < this.tapDelay) {
@@ -451,41 +449,24 @@
 
 
 	/**
-	 * Based on a touchmove event object, check whether the touch has moved past a boundary since it started.
-	 *
-	 * @param {Event} event
-	 * @returns {boolean}
-	 */
-	FastClick.prototype.touchHasMoved = function(event) {
-		var touch = event.changedTouches[0], boundary = this.touchBoundary;
-
-		if (Math.abs(touch.pageX - this.touchStartX) > boundary || Math.abs(touch.pageY - this.touchStartY) > boundary) {
-			return true;
-		}
-
-		return false;
-	};
-
-
-	/**
 	 * Update the last position.
 	 *
 	 * @param {Event} event
 	 * @returns {boolean}
 	 */
-	FastClick.prototype.onTouchMove = function(event) {
-		if (!this.trackingClick) {
-			return true;
-		}
+	//FastClick.prototype.onTouchMove = function(event) {
+	//	if (!this.trackingClick) {
+	//		return true;
+	//	}
 
-		// If the touch has moved, cancel the click tracking
-		if (this.targetElement !== this.getTargetElementFromEventTarget(event.target) || this.touchHasMoved(event)) {
-			this.trackingClick = false;
-			this.targetElement = null;
-		}
+	//	// If the touch has moved, cancel the click tracking
+	//	if (this.targetElement !== this.getTargetElementFromEventTarget(event.target) || this.touchHasMoved(event)) {
+	//		this.trackingClick = false;
+	//		this.targetElement = null;
+	//	}
 
-		return true;
-	};
+	//	return true;
+	//};
 
 
 	/**
@@ -513,6 +494,23 @@
 
 
 	/**
+	 * check whether the touch has moved past a boundary since it started.
+	 *
+	 * @param {Event} event
+	 * @returns {boolean}
+	 */
+	FastClick.prototype.touchHasMoved = function(event) {
+		var touch = event.changedTouches[0], boundary = this.touchBoundary;
+
+		if (Math.abs(touch.clientX- this.touchStartX) > boundary || Math.abs(touch.clientY- this.touchStartY) > boundary) {
+			return true;
+		}
+
+		return false;
+	};
+
+
+	/**
 	 * On touch end, determine whether to send a click event at once.
 	 *
 	 * @param {Event} event
@@ -524,6 +522,12 @@
 		if (!this.trackingClick) {
 			return true;
 		}
+
+        if (this.touchHasMoved(event)) {
+            this.trackingClick = false;
+            this.targetElement = null;
+            return true;
+        }
 
 		// Prevent phantom clicks on fast double-tap (issue #36)
 		if ((event.timeStamp - this.lastClickTime) < this.tapDelay) {
@@ -720,7 +724,6 @@
 
 		layer.removeEventListener('click', this.onClick, true);
 		layer.removeEventListener('touchstart', this.onTouchStart, false);
-		layer.removeEventListener('touchmove', this.onTouchMove, false);
 		layer.removeEventListener('touchend', this.onTouchEnd, false);
 		layer.removeEventListener('touchcancel', this.onTouchCancel, false);
 	};

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -1,4 +1,4 @@
-(function () {
+;(function () {
 	'use strict';
 
 	/**


### PR DESCRIPTION
    fastclick with onTouchMove event listener is not effective, and sometimes may not work well, when I want it work work with some scroll plugin. because every time when I move my finger, it must call a function in fastclick.
    so, now I removed onTouchMove event listener, instead of check whether finger has moved in the onTouchEnd event. 
    In the same time, I need touchStartX  and touchStartY remember clientX and clientY, but not pageX and pageY. because when I scroll the screen, pageX and pageY may not change, but clientX and clientY must changed.