### PR TITLE
calculate trackingClick again in onTouchEnd

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -521,6 +521,12 @@
 	FastClick.prototype.onTouchEnd = function(event) {
 		var forElement, trackingClickStart, targetTagName, scrollParent, touch, targetElement = this.targetElement;
 
+		//check for trackingClick again, otherwise fast swipe in ios will cause a ghost click;
+		if (this.targetElement !== this.getTargetElementFromEventTarget(event.target) || this.touchHasMoved(event)) {
+			this.trackingClick = false;
+			this.targetElement = null;
+		}
+
 		if (!this.trackingClick) {
 			return true;
 		}


### PR DESCRIPTION
### issue  
I found a bug in ios recently. when i do a fast vertically swipe. it will regard as a click event. 

### why
I debug the code.
```javascript
FastClick.prototype.onTouchEnd = function(event) {
       
       if (!this.trackingClick) {     /*when run to there, trackingClick is still true. but  (Math.abs(touch.pageX - this.touchStartX) > boundary || Math.abs(touch.pageY - this.touchStartY) > boundary) is true.  trackingClick should be false.*/
 		return true;
       }
``` 
I think that onTouchMove may not change trackingClick value quickly.

### solution
my solution is calculate trackingClick again in onTouchEnd.
