### PR TITLE
Feature: Change default option values

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -78,7 +78,7 @@
 		 *
 		 * @type number
 		 */
-		this.touchBoundary = options.touchBoundary || 10;
+		this.touchBoundary = options.touchBoundary || 30;
 
 
 		/**
@@ -93,14 +93,21 @@
 		 *
 		 * @type number
 		 */
-		this.tapDelay = options.tapDelay || 200;
+		this.tapDelay = options.tapDelay || 30;
 
 		/**
 		 * The maximum time for a tap
 		 *
 		 * @type number
 		 */
-		this.tapTimeout = options.tapTimeout || 700;
+		this.tapTimeout = options.tapTimeout || 1000;
+
+		/**
+		 * Them minimum tap time for element that needs focus
+		 *
+		 * @type number
+		 */
+		this.focusDelay = options.focusDelay || 100;
 
 		if (FastClick.notNeeded(layer)) {
 			return;
@@ -571,7 +578,8 @@
 
 			// Case 1: If the touch started a while ago (best guess is 100ms based on tests for issue #36) then focus will be triggered anyway. Return early and unset the target element reference so that the subsequent click will be allowed through.
 			// Case 2: Without this exception for input elements tapped when the document is contained in an iframe, then any inputted text won't be visible even though the value attribute is updated as the user types (issue #37).
-			if ((event.timeStamp - trackingClickStart) > 100 || (deviceIsIOS && window.top !== window && targetTagName === 'input')) {
+			// The default value for this.focusDelay is 100ms.
+			if ((event.timeStamp - trackingClickStart) > this.focusDelay || (deviceIsIOS && window.top !== window && targetTagName === 'input')) {
 				this.targetElement = null;
 				return false;
 			}


### PR DESCRIPTION
We found that the old default option values no longer adapt to nowadays' retina screens. These three values seems better and are already used in our production environment.
Besides, it might be a good practice to expose focus delay time option.