### PR TITLE
Fix #466 - make onTouchEnd click async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Thumbs.db
 Desktop.ini
 build
+.idea

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 FastClick is a simple, easy-to-use library for eliminating the 300ms delay between a physical tap and the firing of a `click` event on mobile browsers. The aim is to make your application feel less laggy and more responsive while avoiding any interference with your current logic.
 
+This Ntree fork fixes a bug on touch. https://github.com/ftlabs/fastclick/issues/466
+
 FastClick is developed by [FT Labs](http://labs.ft.com/), part of the Financial Times.
 
 [Explication en français](http://maxime.sh/2013/02/supprimer-le-lag-des-clics-sur-mobile-avec-fastclick/).

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "fastclick",
   "main": "lib/fastclick.js",
+  "version": "1.0.6",
   "ignore": [
     "**/.*",
     "component.json",

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
 	"name": "fastclick",
 	"repo": "ftlabs/fastclick",
 	"description": "Polyfill to remove click delays on browsers with touch UIs.",
-	"version": "1.0.3",
+	"version": "1.0.6",
 	"main": "lib/fastclick.js",
 	"scripts": [
 		"lib/fastclick.js"

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -603,7 +603,7 @@
 		// real clicks or if it is in the whitelist in which case only non-programmatic clicks are permitted.
 		if (!this.needsClick(targetElement)) {
 			event.preventDefault();
-			this.sendClick(targetElement, event);
+			window.setTimeout(this.sendClick.bind(this,targetElement, event));
 		}
 
 		return false;


### PR DESCRIPTION
Certain dom events (e.g. location change, ajax completion) seem to trigger touchend synchronously.  When fastclick then generates the synthetic click, it arrives mid-stack and breaks some assumptions in angular (i.e. click events can't arrive during $digest).  This PR changes wraps the sendClick() call with window.setTimeout to make sure it gets a clean stack.
