### PR TITLE
Add CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Include fastclick.js in your JavaScript bundle or add it to your HTML page like 
 <script type='application/javascript' src='/path/to/fastclick.js'></script>
 ```
 
+Or add it through a CDN:
+
+```
+<script src='https://cdn.jsdelivr.net/npm/fastclick@1/lib/fastclick.js'></script>
+```
+
 The script must be loaded prior to instantiating FastClick on any element of the page.
 
 To instantiate FastClick on the `body`, which is the recommended method of use:


### PR DESCRIPTION
I added [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/fastclick) to your readme, so that people can use files directly without downloading them. jsDelivr is also the [fastest opensource CDN](https://www.cdnperf.com/) available and built specifically for production usage.