### PR TITLE
fix input element double click event

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -326,7 +326,14 @@
 		var length;
 
 		// Issue #160: on iOS 7, some input elements (e.g. date datetime month) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
-		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month' && targetElement.type !== 'email') {
+		if (deviceIsIOS 
+		    && targetElement.setSelectionRange 
+		    && targetElement.type.indexOf('date') !== 0 
+		    && targetElement.type !== 'time' 
+		    && targetElement.type !== 'month' 
+		    && targetElement.type !== 'email'
+		    && targetElement.type !== 'number') 
+		{
 			length = targetElement.value.length;
 			targetElement.setSelectionRange(length, length);
 		} else {


### PR DESCRIPTION
修复当事件源类型为number时,双击出错,导致JS出错!JS脚本无法运行
When the event source type is number, double-click the error, resulting in JS error! JS script can not run.
setSelectionRange method Cannot type does not support number.
Sorry, my English is not very good.