### PR TITLE
fix: blackberryVersion is null

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -772,7 +772,7 @@
 
 			// BlackBerry 10.3+ does not require Fastclick library.
 			// https://github.com/ftlabs/fastclick/issues/251
-			if (blackberryVersion[1] >= 10 && blackberryVersion[2] >= 3) {
+			if (blackberryVersion && blackberryVersion[1] >= 10 && blackberryVersion[2] >= 3) {
 				metaViewport = document.querySelector('meta[name=viewport]');
 
 				if (metaViewport) {


### PR DESCRIPTION
```js
var deviceIsBlackBerry10 = navigator.userAgent.indexOf('BB10') > 0;
```
The BB10 is common, so there should be a detection for blackberryVersion to prevent TypeError.