### PR TITLE
fix: #551

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -329,6 +329,7 @@
 		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month' && targetElement.type !== 'email') {
 			length = targetElement.value.length;
 			targetElement.setSelectionRange(length, length);
+      if (!length) targetElement.focus();
 		} else {
 			targetElement.focus();
 		}
@@ -636,7 +637,9 @@
 
 		if (event.forwardedTouchEvent) {
 			return true;
-		}
+		} else {
+      this.targetElement = this.getTargetElementFromEventTarget(event.target);
+    }
 
 		// Programmatically generated events targeting a specific element should be permitted
 		if (!event.cancelable) {


### PR DESCRIPTION
fix :
1. When textarea has no content, textarea cannot be focused on very fast;
2. Cannot trigger input[type=file].click() in another click event.

Sorry, I'm not good at English...