### PR TITLE
Try to fix negative event.timeStamp values on iOS 11.3/4

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -328,6 +328,21 @@
 		// Issue #160: on iOS 7, some input elements (e.g. date datetime month) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
 		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month' && targetElement.type !== 'email') {
 			length = targetElement.value.length;
+
+      // Calling focus() here fixes this:
+      // https://github.com/ftlabs/fastclick/issues/548
+      //
+      // No idea why this works, but calling focus() fixes at least this scenario:
+      // - iOS 11.3
+      // - Cordova with UIWebView
+      // - Open page with datetime input and text input
+      // - Tap datetime input, close the popup
+      // - Quickly tap text input
+      // -> Nothing happens (this is fixed by calling focus())
+      // - Tap text input for a longer time
+      // -> Text input is focused
+      targetElement.focus();
+
 			targetElement.setSelectionRange(length, length);
 		} else {
 			targetElement.focus();

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -405,19 +405,13 @@
 	 */
 	FastClick.prototype.onTouchStart = function(event) {
 		var targetElement, touch, selection, touchStartTime;
-		
+
 		// iOS (at least 11.4 and 11.4 beta) can return smaller event.timeStamp values after resuming with
 		// Cordova using UIWebView (and possibly also with mobile Safari?), the timeStamp values can also
 		// be negative
 		// https://github.com/ftlabs/fastclick/issues/549
-		if (event.timeStamp < 0) {
-			touchStartTime = (new Date()).getTime();
-			this.isTrackingClickStartFromEvent = false;
-		} else {
-			touchStartTime = event.timeStamp;
-			this.isTrackingClickStartFromEvent = true;
-		}
-		
+		touchStartTime = (new Date()).getTime();
+
 		// Ignore multiple touches, otherwise pinch-to-zoom is prevented if both fingers are on the FastClick element (issue #111).
 		if (event.targetTouches.length > 1) {
 			return true;
@@ -547,16 +541,12 @@
 	 */
 	FastClick.prototype.onTouchEnd = function(event) {
 		var forElement, trackingClickStart, targetTagName, scrollParent, touch, touchEndTime, targetElement = this.targetElement;
-	
-		if (this.isTrackingClickStartFromEvent) {
-			touchEndTime = event.timeStamp;
-		} else {
-			// iOS (at least 11.4 and 11.4 beta) can return smaller event.timeStamp values after resuming with
-			// Cordova using UIWebView (and possibly also with mobile Safari?), the timeStamp values can also
-			// be negative
-			// https://github.com/ftlabs/fastclick/issues/549
-			touchEndTime = (new Date()).getTime();
-		}
+
+		// iOS (at least 11.4 and 11.4 beta) can return smaller event.timeStamp values after resuming with
+		// Cordova using UIWebView (and possibly also with mobile Safari?), the timeStamp values can also
+		// be negative
+		// https://github.com/ftlabs/fastclick/issues/549
+		touchEndTime = (new Date()).getTime();
 
 		if (!this.trackingClick) {
 			return true;

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -389,7 +389,12 @@
 	 * @returns {boolean}
 	 */
 	FastClick.prototype.onTouchStart = function(event) {
-		var targetElement, touch, selection;
+		var targetElement, touch, selection, touchStartTime;
+
+		// Do not use event.timeStamp
+		// iOS 11.3 returns negative values for event.timeStamp after pausing/resuming a Cordova application
+		// and supposedly for mobile Safari as well
+		touchStartTime = (new Date()).getTime();
 
 		// Ignore multiple touches, otherwise pinch-to-zoom is prevented if both fingers are on the FastClick element (issue #111).
 		if (event.targetTouches.length > 1) {
@@ -435,14 +440,14 @@
 		}
 
 		this.trackingClick = true;
-		this.trackingClickStart = event.timeStamp;
+		this.trackingClickStart = touchStartTime;
 		this.targetElement = targetElement;
 
 		this.touchStartX = touch.pageX;
 		this.touchStartY = touch.pageY;
 
 		// Prevent phantom clicks on fast double-tap (issue #36)
-		if ((event.timeStamp - this.lastClickTime) < this.tapDelay) {
+		if ((touchStartTime - this.lastClickTime) < this.tapDelay) {
 			event.preventDefault();
 		}
 
@@ -519,26 +524,31 @@
 	 * @returns {boolean}
 	 */
 	FastClick.prototype.onTouchEnd = function(event) {
-		var forElement, trackingClickStart, targetTagName, scrollParent, touch, targetElement = this.targetElement;
+		var forElement, trackingClickStart, targetTagName, scrollParent, touch, touchEndTime, targetElement = this.targetElement;
+
+		// Do not use event.timeStamp
+		// iOS 11.3 returns negative values for event.timeStamp after pausing/resuming a Cordova application
+		// and supposedly for mobile Safari as well
+		touchEndTime = (new Date()).getTime();
 
 		if (!this.trackingClick) {
 			return true;
 		}
 
 		// Prevent phantom clicks on fast double-tap (issue #36)
-		if ((event.timeStamp - this.lastClickTime) < this.tapDelay) {
+		if ((touchEndTime - this.lastClickTime) < this.tapDelay) {
 			this.cancelNextClick = true;
 			return true;
 		}
 
-		if ((event.timeStamp - this.trackingClickStart) > this.tapTimeout) {
+		if ((touchEndTime - this.trackingClickStart) > this.tapTimeout) {
 			return true;
 		}
 
 		// Reset to prevent wrong click cancel on input (issue #156).
 		this.cancelNextClick = false;
 
-		this.lastClickTime = event.timeStamp;
+		this.lastClickTime = touchEndTime;
 
 		trackingClickStart = this.trackingClickStart;
 		this.trackingClick = false;
@@ -571,7 +581,7 @@
 
 			// Case 1: If the touch started a while ago (best guess is 100ms based on tests for issue #36) then focus will be triggered anyway. Return early and unset the target element reference so that the subsequent click will be allowed through.
 			// Case 2: Without this exception for input elements tapped when the document is contained in an iframe, then any inputted text won't be visible even though the value attribute is updated as the user types (issue #37).
-			if ((event.timeStamp - trackingClickStart) > 100 || (deviceIsIOS && window.top !== window && targetTagName === 'input')) {
+			if ((touchEndTime - trackingClickStart) > 100 || (deviceIsIOS && window.top !== window && targetTagName === 'input')) {
 				this.targetElement = null;
 				return false;
 			}

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -205,6 +205,13 @@
 
 
 	/**
+	 * iOS 11.3 has a bug that returns negative event.timeStamp values
+	 *
+	 * @type boolean
+	 */
+	var deviceIsIOS11_3 = deviceIsIOS && (/OS 11_3(_\d)?/).test(navigator.userAgent);
+
+	/**
 	 * iOS 6.0-7.* requires the target element to be manually derived
 	 *
 	 * @type boolean
@@ -391,10 +398,14 @@
 	FastClick.prototype.onTouchStart = function(event) {
 		var targetElement, touch, selection, touchStartTime;
 
-		// Do not use event.timeStamp
-		// iOS 11.3 returns negative values for event.timeStamp after pausing/resuming a Cordova application
-		// and supposedly for mobile Safari as well
-		touchStartTime = (new Date()).getTime();
+		if (deviceIsIOS11_3) {
+			// Do not use event.timeStamp
+			// iOS 11.3 returns negative values for event.timeStamp after pausing/resuming a Cordova application
+			// and supposedly for mobile Safari as well
+			touchStartTime = (new Date()).getTime();
+		} else {
+			touchStartTime = event.timeStamp;
+		}
 
 		// Ignore multiple touches, otherwise pinch-to-zoom is prevented if both fingers are on the FastClick element (issue #111).
 		if (event.targetTouches.length > 1) {
@@ -526,10 +537,14 @@
 	FastClick.prototype.onTouchEnd = function(event) {
 		var forElement, trackingClickStart, targetTagName, scrollParent, touch, touchEndTime, targetElement = this.targetElement;
 
-		// Do not use event.timeStamp
-		// iOS 11.3 returns negative values for event.timeStamp after pausing/resuming a Cordova application
-		// and supposedly for mobile Safari as well
-		touchEndTime = (new Date()).getTime();
+		if (deviceIsIOS11_3) {
+			// Do not use event.timeStamp
+			// iOS 11.3 returns negative values for event.timeStamp after pausing/resuming a Cordova application
+			// and supposedly for mobile Safari as well
+			touchEndTime = (new Date()).getTime();
+		} else {
+			touchEndTime = event.timeStamp;
+		}
 
 		if (!this.trackingClick) {
 			return true;

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -205,13 +205,6 @@
 
 
 	/**
-	 * iOS 11.3 has a bug that returns negative event.timeStamp values
-	 *
-	 * @type boolean
-	 */
-	var deviceIsIOS11_3 = deviceIsIOS && (/OS 11_3(_\d)?/).test(navigator.userAgent);
-
-	/**
 	 * iOS 6.0-7.* requires the target element to be manually derived
 	 *
 	 * @type boolean
@@ -397,16 +390,18 @@
 	 */
 	FastClick.prototype.onTouchStart = function(event) {
 		var targetElement, touch, selection, touchStartTime;
-
-		if (deviceIsIOS11_3) {
-			// Do not use event.timeStamp
-			// iOS 11.3 returns negative values for event.timeStamp after pausing/resuming a Cordova application
-			// and supposedly for mobile Safari as well
+		
+		// iOS (at least 11.3 and 11.4 beta) returns negative values for event.timeStamp after pausing/resuming a Cordova application
+		// and supposedly for mobile Safari as well
+		// https://github.com/ftlabs/fastclick/issues/549
+		if (event.timeStamp < 0) {
 			touchStartTime = (new Date()).getTime();
+			this.isTrackingClickStartFromEvent = false;
 		} else {
 			touchStartTime = event.timeStamp;
+			this.isTrackingClickStartFromEvent = true;
 		}
-
+		
 		// Ignore multiple touches, otherwise pinch-to-zoom is prevented if both fingers are on the FastClick element (issue #111).
 		if (event.targetTouches.length > 1) {
 			return true;
@@ -536,14 +531,14 @@
 	 */
 	FastClick.prototype.onTouchEnd = function(event) {
 		var forElement, trackingClickStart, targetTagName, scrollParent, touch, touchEndTime, targetElement = this.targetElement;
-
-		if (deviceIsIOS11_3) {
-			// Do not use event.timeStamp
-			// iOS 11.3 returns negative values for event.timeStamp after pausing/resuming a Cordova application
-			// and supposedly for mobile Safari as well
-			touchEndTime = (new Date()).getTime();
-		} else {
+	
+		if (this.isTrackingClickStartFromEvent) {
 			touchEndTime = event.timeStamp;
+		} else {
+			// iOS (at least 11.3 and 11.4 beta) returns negative values for event.timeStamp after pausing/resuming a Cordova application
+			// and supposedly for mobile Safari as well
+			// https://github.com/ftlabs/fastclick/issues/549
+			touchEndTime = (new Date()).getTime();
 		}
 
 		if (!this.trackingClick) {

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -391,8 +391,9 @@
 	FastClick.prototype.onTouchStart = function(event) {
 		var targetElement, touch, selection, touchStartTime;
 		
-		// iOS (at least 11.3 and 11.4 beta) returns negative values for event.timeStamp after pausing/resuming a Cordova application
-		// and supposedly for mobile Safari as well
+		// iOS (at least 11.4 and 11.4 beta) can return smaller event.timeStamp values after resuming with
+		// Cordova using UIWebView (and possibly also with mobile Safari?), the timeStamp values can also
+		// be negative
 		// https://github.com/ftlabs/fastclick/issues/549
 		if (event.timeStamp < 0) {
 			touchStartTime = (new Date()).getTime();
@@ -535,8 +536,9 @@
 		if (this.isTrackingClickStartFromEvent) {
 			touchEndTime = event.timeStamp;
 		} else {
-			// iOS (at least 11.3 and 11.4 beta) returns negative values for event.timeStamp after pausing/resuming a Cordova application
-			// and supposedly for mobile Safari as well
+			// iOS (at least 11.4 and 11.4 beta) can return smaller event.timeStamp values after resuming with
+			// Cordova using UIWebView (and possibly also with mobile Safari?), the timeStamp values can also
+			// be negative
 			// https://github.com/ftlabs/fastclick/issues/549
 			touchEndTime = (new Date()).getTime();
 		}


### PR DESCRIPTION
This change is the same as https://github.com/ftlabs/fastclick/pull/550, but uses Date.getTime() for all touchstart/end events instead of just ones where the timestamp was negative.