### PR TITLE
Issue #160: Added targetElement type number to check

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -326,12 +326,13 @@
 		var length;
 
 		// Issue #160: on iOS 7, some input elements (e.g. date datetime month) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
-		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month' && targetElement.type !== 'email') {
+		if (deviceIsIOS && targetElement.setSelectionRange && !['date', 'time', 'month', 'email', 'number'].includes(targetElement.type)) {
 			length = targetElement.value.length;
 			targetElement.setSelectionRange(length, length);
 		} else {
 			targetElement.focus();
 		}
+		targetElement.focus();
 	};
 
 


### PR DESCRIPTION
Error: `Uncaught DOMException: Failed to execute 'setSelectionRange' on 'HTMLInputElement': The input element's type ('number') does not support selection.`

Affected: iPhones and iPads

Input types: date, time, month, email, number