### PR TITLE
allow event if targetElement does not exist in the DOM anymore

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -302,8 +302,19 @@
 		touch = event.changedTouches[0];
 
 		// Synthesise a click event, with an extra attribute so it can be tracked
-		clickEvent = document.createEvent('MouseEvents');
-		clickEvent.initMouseEvent(this.determineEventType(targetElement), true, true, window, 1, touch.screenX, touch.screenY, touch.clientX, touch.clientY, false, false, false, false, 0, null);
+		clickEvent = new MouseEvent(this.determineEventType(targetElement), {
+			bubbles: true,
+			cancelable: true,
+			screenX: touch.screenX,
+			screenY: touch.screenY,
+			clientX: touch.clientX,
+			clientY: touch.clientY,
+			ctrlKey: false,
+			shiftKey: false,
+			altKey: false,
+			metaKey: false,
+			relatedTarget: null
+		});
 		clickEvent.forwardedTouchEvent = true;
 		targetElement.dispatchEvent(clickEvent);
 	};

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -645,6 +645,12 @@
 			return true;
 		}
 
+		// If the target element does not exist in the DOM anymore, 
+		// this.targetElement does not refer to anything so we should allow the event since actual target is obviously different
+		if (!document.contains(this.targetElement)) {
+			return true;
+		}
+
 		if (event.forwardedTouchEvent) {
 			return true;
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "fastclick",
+  "version": "1.0.6",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
Hello, I've been working on a bug with an app that uses your library (by the way I have to say it's awesome) and I thought of the following case: 

When we are on a popup which displays with a grayout (like a modal) and you click on the grayout to hide the popup (and the grayout of course) and then you click on what was overlayed by the popup, then you have a strange issue: you have to click twice in order to trigger the actual click event. I had a look and it seems like, at the first click after the popup closure, the variable `this.targetElement` is still refering to the grayout element that actually disappeared from the dom. That's what my second commit tries to fix.
The first commit is just to update the mouseEvent instanciation: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/initMouseEvent