### PR TITLE
Check CommonJS module first

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -826,15 +826,14 @@
 	};
 
 
-	if (typeof define === 'function' && typeof define.amd === 'object' && define.amd) {
-
+	if (typeof module !== 'undefined' && module.exports) {
+		module.exports = FastClick.attach;
+		module.exports.FastClick = FastClick;
+	} else if (typeof define === 'function' && typeof define.amd === 'object' && define.amd) {
 		// AMD. Register as an anonymous module.
 		define(function() {
 			return FastClick;
 		});
-	} else if (typeof module !== 'undefined' && module.exports) {
-		module.exports = FastClick.attach;
-		module.exports.FastClick = FastClick;
 	} else {
 		window.FastClick = FastClick;
 	}


### PR DESCRIPTION
When importing this module from ES modules, it loads AMD first because Webpack provides all AMD, CommonJS and other module support. 

In order to resolve this issue, we should check for the CommonJS module first.